### PR TITLE
Try to get renovate to ignore bazel dist dir:

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
 	"allowScripts": true,
 	"rollbackPrs": true,
 	"recreateClosed": true,
-	"ignorePaths": ["dist/**"],
+	"ignorePaths": ["**/monorepo/dist/**"],
 	"gitIgnoredAuthors": [ "zemnmez+renovate@gmail.com" ],
     "autodiscoverFilter": [ "zemn-me/monorepo" ],
 	"allowedPostUpgradeCommands": [


### PR DESCRIPTION
Try to get renovate to ignore bazel dist dir:

ERR_PNPM_JSON_PARSE Expected property name or '}' in JSON at position 2 while parsing '{' in /tmp/renovate/repos/github/zemn-me/monorepo/dist/monorepo/dist/monorepo/dist/monorepo/dist/monorepo/dist/monorepo/dist/monorepo/dist/monorepo/dist/monorepo/dist/monorepo/external/npm__resolve__1.22.2/package/test/resolver/malformed_package_json/package.json

  1 | {
> 2 |
    | ^
