### PR TITLE
Delete bazel "dist" folder after post upgrade tasks to prevent pnpm getting confused.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
     "autodiscoverFilter": [ "zemn-me/monorepo" ],
 	"allowedPostUpgradeCommands": [
 		"CARGO_BAZEL_REPIN=1 npx --yes @bazel/bazelisk sync --only=cargo",
-		"npx --yes @bazel/bazelisk run //bzl/fix_api:fix_all //..."
+		"npx --yes @bazel/bazelisk run //bzl/fix_api:fix_all //...",
+		"rm -rf dist"
 	],
 	"packageRules": [
 		{
@@ -24,7 +25,8 @@
 			"postUpgradeTasks": {
 				"commands": [
 					"CARGO_BAZEL_REPIN=1 npx --yes @bazel/bazelisk sync --only=cargo",
-					"npx --yes @bazel/bazelisk run //bzl/fix_api:fix_all //..."
+					"npx --yes @bazel/bazelisk run //bzl/fix_api:fix_all //...",
+					"rm -rf dist"
 				],
 				"executionMode": "branch",
 				"fileFilters": [ "Cargo.Bazel.lock", "Cargo.toml", "cargo-bazel-lock.json", "**/*.ts"],


### PR DESCRIPTION
Delete bazel "dist" folder after post upgrade tasks to prevent pnpm getting confused.

https://github.com/zemn-me/monorepo/pull/3848#issuecomment-1784026554
