### PR TITLE
Remove pull request presubmit concurrency limit.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,6 @@ on:   # yamllint disable-line rule:truthy
 
 jobs:
   Presubmit:
-    # this should stop presubmits being run even when there
-    # is a successor commit in pull request.
-    concurrency:
-      group: concurrency-ci-${{ github.head_ref }}
-      cancel-in-progress: true
     # github's security settings mean that pull requests
     # can only pull from the upstream 'main' cache.
     #


### PR DESCRIPTION
Remove pull request presubmit concurrency limit.

Unfortunately, this appears to have caused a problem when interacting with sapling such that
sapling pushing an amended commit would just cause both the running task AND the task
at the new head being tested.

Removing this entirely means that both tests will be run -- but tests don't take that
long these days anyway.
