### PR TITLE
Back out "Add SPF record to Website.". This reverts commit: 781534737fa2a10b6dff8b93f902255f01062e26

### DIFF
--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -387,15 +387,6 @@ export class Website extends pulumi.ComponentResource {
 			{ parent: this, deleteBeforeReplace: true }
 		);
 
-		// set SPF record indicating we'll only use this with Google Workspaces.
-		new aws.route53.Record(`${name}_spf`, {
-			zoneId: args.zoneId,
-			name: args.domain,
-			type: 'TXT',
-			records: ['v=spf1 include:_spf.google.com ~all'],
-			ttl: 43200,
-		});
-
 		this.registerOutputs({
 			distribution,
 			record,


### PR DESCRIPTION
Back out "Add SPF record to Website.". This reverts commit: 781534737fa2a10b6dff8b93f902255f01062e26

In https://github.com/zemn-me/monorepo/pull/3963, I said this would probably fail, but it had skipped my mind that it would probably fail at submit time rather than staging time because the TXT records this collides with are defined directly in the AWS console, not in Pulumi.

I think the best solution to this in the long run would be to move the TXT records into 'Website' in ts/pulumi/lib via a new TXT field or something. Then I can have Website inject the SPF records for each Website. Issue for this: https://github.com/zemn-me/monorepo/issues/3964

Pulumi update error:

```
Diagnostics:
  pulumi:pulumi:Stack (Zemnmez/monorepo-2/prod)
    error: update failed

  aws:route53:Record (monorepo_zemn.me_zemn_me_spf)
    error: 1 error occurred:
	* creating Route 53 Record: InvalidChangeBatch: [Tried to create resource record set [name='zemn.me.', type='TXT'] but it already exists]
	status code: 400, request id: 3e0c725a-c2bc-4ed4-a530-3d3e9f6df4d6
```
