### PR TITLE
rules_python corrections necessitated in https://github.com/zemn-me/monorepo/pull/3852

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,21 +25,14 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+load("@rules_python//python:repositories.bzl", "py_repositories")
 
-python_register_toolchains(
-    name = "python3_9",
-    # Available versions are listed in @rules_python//python:versions.bzl.
-    # We recommend using the same version your team is already standardized on.
-    python_version = "3.9",
-)
+py_repositories()
 
-load("@python3_9//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 pip_parse(
     name = "pip",
-    python_interpreter_target = interpreter,
     # pip-compile
     requirements_lock = "//:requirements.txt",
 )


### PR DESCRIPTION
rules_python corrections necessitated in https://github.com/zemn-me/monorepo/pull/3852

- Remove register_toolchains which has not been needed since 0.23.0 https://github.com/bazelbuild/rules_python/releases/tag/0.23.0
- Add py_repositories which has been possible to omit before, but is mandatory since 0.26.0 https://github.com/bazelbuild/rules_python/releases/tag/0.26.0
