### PR TITLE
Do not presubmit on push.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,10 @@ on:   # yamllint disable-line rule:truthy
 
 jobs:
   Presubmit:
-    # github's security settings mean that pull requests
-    # can only pull from the upstream 'main' cache.
-    #
-    # This means we need to run these tests so that
-    # PRs can be sped up by loading their cached results.
     if: >
       github.event_name == 'pull_request'
       || github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
-      || github.event_name == 'push'
     # Performs all offline testing.
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Do not presubmit on push.

This was previously needed because github cache was used instead of BuildBuddy. Now that BuildBuddy is used, it's not needed.
