### PR TITLE
Remove setup-chrome from the presubmit. The test it was used for has been disabled.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,6 @@ jobs:
           large-packages: false
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      # attempt at addressing
-      # https://github.com/puppeteer/puppeteer/issues/11001
-      # //ts/cmd/svgshot (puppeteer) uses this.
-      - uses: browser-actions/setup-chrome@11cef13cde73820422f9263a707fb8029808e191 # v1
       # example copied from:
       # https://github.com/actions/cache/blob/04f198bf0b2a39f7230a4304bf07747a0bddf146/examples.md
       - name: Presubmit


### PR DESCRIPTION
Remove setup-chrome from the presubmit. The test it was used for has been disabled.
