### PR TITLE
Renovate: set rangeStrategy to "pin" as a workaround for https://github.com/renovatebot/renovate/issues/21438

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
 	"platformCommit": true,
 	"allowScripts": true,
 	"rollbackPrs": true,
+	"rangeStrategy": "pin",
 	"recreateWhen": "always",
 	"ignorePaths": ["**/monorepo/dist/**"],
 	"gitIgnoredAuthors": ["zemnmez+renovate@gmail.com"],


### PR DESCRIPTION
Renovate: set rangeStrategy to "pin" as a workaround for https://github.com/renovatebot/renovate/issues/21438

See also: https://github.com/renovatebot/renovate/discussions/22133#discussioncomment-5886419
