### PR TITLE
Back out "Accept SVGShot tests not passing for now."

### DIFF
--- a/ts/cmd/svgshot/svgshot_test.ts
+++ b/ts/cmd/svgshot/svgshot_test.ts
@@ -5,8 +5,7 @@ import main from 'ts/cmd/svgshot/lib';
 jest.setTimeout(30000);
 
 describe('svgshot', () => {
-	// TODO(zemnmez) -- uncomment this when I fix puppeteer.
-	it.skip('should render a test URL', async () => {
+	it('should render a test URL', async () => {
 		const [target, cleanup] = await new Promise<[string, () => void]>(
 			(ok, err) =>
 				tmp.file(


### PR DESCRIPTION
Back out "Accept SVGShot tests not passing for now."

I think it's possible that pinning the deps has fixed whatever issue we were experiencing here.

Original commit changeset: dfb28ef2c124
