### PR TITLE
Enable es6 module syntax via node subpackage imports.

### DIFF
--- a/.swcrc.json
+++ b/.swcrc.json
@@ -26,6 +26,6 @@
     }
   },
   "module": {
-    "type": "commonjs"
+    "type": "es6"
   }
 }

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -1,1 +1,5 @@
-# Nothing in here yet!
+filegroup(
+	name = "js_binary_deps",
+	srcs = [ "//:package_json" ],
+	visibility = [ "//:__subpackages__" ]
+)

--- a/js/jest/rules.bzl
+++ b/js/jest/rules.bzl
@@ -29,7 +29,7 @@ def jest_test(name, srcs = [], data = [], deps = [], jest_config = "//:jest.ts.c
     # This rule is used specifically to update snapshots via `bazel run`
     jest.jest_binary(
         name = "%s.update" % name,
-        data = data,
+        data = data + [ "//js:js_binary_deps" ],
         args = args + ["-u"],
         **kwargs
     )

--- a/package.json
+++ b/package.json
@@ -120,5 +120,9 @@
 		"overrides": {
 			"resolve": "^2.0.0-next.5"
 		}
-	}
+	},
+	"imports": {
+		"#monorepo/*.js": "./*.js"
+	},
+	"type": "module"
 }

--- a/ts/testing/import_test/a.ts
+++ b/ts/testing/import_test/a.ts
@@ -1,4 +1,4 @@
-import * as b from 'ts/testing/import_test/b';
+import * as b from '#monorepo/ts/testing/import_test/b.js';
 
 const copy: string = b.MyString;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"compilerOptions": {
-		"module": "CommonJS",
+		"module": "Node16",
 		"target": "es2020",
 		"strictFunctionTypes": true,
 		"esModuleInterop": true,
-		"moduleResolution": "node",
+		"moduleResolution": "Node16",
 		"strict": true,
 		"jsx": "react-jsx",
 		"resolveJsonModule": true,
@@ -19,7 +19,7 @@
 		"lib": ["DOM", "ESNext"],
 		"baseUrl": ".",
 		"paths": {
-			"*": [ "*", "dist/bin/*" ],
+			"#monorepo/*": [ "*", "dist/bin/*" ],
 		}
 	},
 	"exclude": ["node_modules", "dist", "external"]


### PR DESCRIPTION
Enable es6 module syntax via node subpackage imports.
