### PR TITLE
Back out "Revert 050d0541d9f91d884a1f1ec41c70e59c8476386a to remove all txt records in preparation for adoption."

### DIFF
--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -387,10 +387,26 @@ export class Website extends pulumi.ComponentResource {
 			{ parent: this, deleteBeforeReplace: true }
 		);
 
+		const txt_record = new aws.route53.Record(
+			`${name}_txt_record`,
+			{
+				zoneId: args.zoneId,
+				name: args.domain,
+				type: 'TXT',
+				records: [
+					'google-site-verification=plPeQFN6n0_8HZ8hr3HMXbYHrU_Yh5wPP9OUwH0ErGY',
+					'v=spf1 include:_spf.google.com ~all',
+				],
+				ttl: 1800,
+			},
+			{ protect: false }
+		);
+
 		this.registerOutputs({
 			distribution,
 			record,
 			bucketPolicy,
+			txt_record,
 		});
 	}
 }


### PR DESCRIPTION
Back out "Revert 050d0541d9f91d884a1f1ec41c70e59c8476386a to remove all txt records in preparation for adoption."

This should roll-forward the appropriate TXT records under pulumi, putting them all
under our control.

Original commit changeset: ca47f380ff48
