### PR TITLE
Have Go for vscode use the bazel workspace's version of go.

### DIFF
--- a/.vscode/go.sh
+++ b/.vscode/go.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec bazel run --tool_tag=go -- @io_bazel_rules_go//go "${@}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,8 @@
 	"go.buildOnSave": "off",
 	"go.lintOnSave": "off",
 	"go.vetOnSave": "off",
-	"typescript.preferences.importModuleSpecifier": "non-relative"
+	"typescript.preferences.importModuleSpecifier": "non-relative",
+	"go.alternateTools": {
+		"go": "${workspaceFolder}/.vscode/go.sh"
+	}
 }

--- a/.vscode/testing/BUILD.bazel
+++ b/.vscode/testing/BUILD.bazel
@@ -1,0 +1,13 @@
+sh_test(
+	name = "test_tools_run",
+	srcs = [ "test_tools_run.sh" ],
+	deps = [
+		"@bazel_tools//tools/bash/runfiles",
+	],
+	data = [
+		"@io_bazel_rules_go//go",
+	],
+	env = {
+		"GO_BINARY": "$(rlocationpath @io_bazel_rules_go//go)"
+	}
+)

--- a/.vscode/testing/test_tools_run.sh
+++ b/.vscode/testing/test_tools_run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+
+# this is a hack because the go_bin_runner chdirs into BUILD_WORKING_DIRECTORY
+# which may make sense in some contexts but does not make sense in a smoke test.
+# https://github.com/bazelbuild/rules_go/blob/0a6311cdc4a643f9f99b8109c44773f4a295c60e/go/tools/go_bin_runner/main.go#L34
+BUILD_WORKING_DIRECTORY="." $(rlocation $GO_BINARY) version
+


### PR DESCRIPTION
Have Go for vscode use the bazel workspace's version of go.
