### PR TITLE
Remove vscode specific go and gopackagesdriver binaries and instead rely on sh/bin

### DIFF
--- a/.vscode/go.sh
+++ b/.vscode/go.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
-cd $1
-exec bazel run --tool_tag=go -- @io_bazel_rules_go//go "${@}"
+"$(dirname ${BASH_SOURCE[0]})/../sh/bin/go" "${@}"

--- a/.vscode/go.sh
+++ b/.vscode/go.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-"$(dirname ${BASH_SOURCE[0]})/../sh/bin/go" "${@}"

--- a/.vscode/gopackagesdriver.sh
+++ b/.vscode/gopackagesdriver.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-# https://github.com/bazelbuild/rules_go/wiki/Editor-setup#2-launcher-script
-"$(dirname ${BASH_SOURCE[0]})/../sh/bin/gopackagesdriver" "${@}"

--- a/.vscode/gopackagesdriver.sh
+++ b/.vscode/gopackagesdriver.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # https://github.com/bazelbuild/rules_go/wiki/Editor-setup#2-launcher-script
-exec bazel run --tool_tag=gopackagesdriver -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"
+"$(dirname ${BASH_SOURCE[0]})/../sh/bin/gopackagesdriver" "${@}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,7 @@
 	},
 	"go.goroot": "${workspaceFolder}/bazel-${workspaceFolderBasename}/external/go_sdk",
 	"go.toolsEnvVars": {
-		"GOPACKAGESDRIVER": "${workspaceFolder}/.vscode/gopackagesdriver.sh"
+		"GOPACKAGESDRIVER": "${workspaceFolder}/sh/bin/gopackagesdriver"
 	},
 	"go.enableCodeLens": {
 		"runtest": false
@@ -58,6 +58,6 @@
 	"go.vetOnSave": "off",
 	"typescript.preferences.importModuleSpecifier": "non-relative",
 	"go.alternateTools": {
-		"go": "${workspaceFolder}/.vscode/go.sh ${workspaceFolder}"
+		"go": "${workspaceFolder}/sh/bin/go"
 	}
 }

--- a/sh/bin/README.md
+++ b/sh/bin/README.md
@@ -1,0 +1,6 @@
+sh/bin
+------
+
+This is intended to be a suite of tools that shadow the usual dev tools you have on your system
+such as `go`, `python` so that you can add this to your PATH and use the latest versions
+kept up to date in the monorepo and compatible with your architecture.

--- a/sh/bin/go
+++ b/sh/bin/go
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" @io_bazel_rules_go//go "${@}"

--- a/sh/bin/gopackagesdriver
+++ b/sh/bin/gopackagesdriver
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"

--- a/sh/run_bazel.sh
+++ b/sh/run_bazel.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# runs a binary built by bazel in this repo
+cd $(dirname ${BASH_SOURCE[0]})
+
+bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress -- "${@}"
+


### PR DESCRIPTION
Remove vscode specific go and gopackagesdriver binaries and instead rely on sh/bin

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/4358).
* __->__ #4358
* #4356