### PR TITLE
Make @zemnmez the sole owner of the files that dependabot might change.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,16 +7,17 @@
 /ts/pulumi/shadwell/im/kate/pages/_document.tsx @zemnmez
 
 # list of files that dependabot might change
-/cargo-bazel-lock.json @zemn-me/renovate_approvers
-/go.mod @zemn-me/renovate_approvers
-/go.sum @zemn-me/renovate_approvers
-/pnpm-lock.yaml @zemn-me/renovate_approvers
-/package.json @zemn-me/renovate_approvers
-/Cargo.Bazel.lock @zemn-me/renovate_approvers
-/Cargo.toml @zemn-me/renovate_approvers
-/renovate.json @zemn-me/renovate_approvers
-/requirements.in @zemn-me/renovate_approvers
-/requirements.txt @zemn-me/renovate_approvers
-/bzl/deps.bzl @zemn-me/renovate_approvers
+# gotta all be owned by me until https://github.com/orgs/community/discussions/9636
+/cargo-bazel-lock.json @zemnmez
+/go.mod @zemnmez
+/go.sum @zemnmez
+/pnpm-lock.yaml @zemnmez
+/package.json @zemnmez
+/Cargo.Bazel.lock @zemnmez
+/Cargo.toml @zemnmez
+/renovate.json @zemnmez
+/requirements.in @zemnmez
+/requirements.txt @zemnmez
+/bzl/deps.bzl @zemnmez
 
 


### PR DESCRIPTION
Make @zemnmez the sole owner of the files that dependabot might change.

Because of https://github.com/orgs/community/discussions/9636, it's not possible
to have single-person aprovals for CODEOWNERS unless there is only one and
exactly one owner (and not a group).

This means by previously having these also owned by the bot, while intended
to have the bot self-approve for these changes it actually meant that
I, @zemnmez, had to bypass branch checks every single time or log
into a bot account to get approval.
