### PR TITLE
Add bazel / bazelisk to sh/bin and use bazelisk for all bazel commands.

### DIFF
--- a/sh/bin/bazel
+++ b/sh/bin/bazel
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+"$(dirname ${BASH_SOURCE[0]})"/bazelisk "${@}"
+
+

--- a/sh/bin/bazelisk
+++ b/sh/bin/bazelisk
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+npx @bazel/bazelisk "${@}"

--- a/sh/run_bazel.sh
+++ b/sh/run_bazel.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # runs a binary built by bazel in this repo
+BAZEL="$(realpath $(dirname ${BASH_SOURCE[0]})/bin/bazel)"
 cd $(dirname ${BASH_SOURCE[0]})
 
-bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress -- "${@}"
+$BAZEL run --ui_event_filters=-info,-stdout,-stderr --noshow_progress -- "${@}"
 


### PR DESCRIPTION
Add bazel / bazelisk to sh/bin and use bazelisk for all bazel commands.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/4379).
* #4380
* __->__ #4379