### PR TITLE
Add --tool_tag tracking to presubmit.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
          bazel build //ci:presubmit && \
          echo "::endgroup::" && \
          echo "::group::Presubmit" && \
-         bazel run //ci:presubmit -- --skip-pulumi-deploy && \
+         bazel run --tool_tag=presubmit //ci:presubmit -- --skip-pulumi-deploy && \
          echo "::endgroup::"
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -91,7 +91,7 @@ jobs:
             bazel build //ci:presubmit && \
             echo "::endgroup::" && \
             echo "::group::Presubmit" && \
-            bazel run //ci:presubmit -- --skip-bazel-tests --dirty \
+            bazel run --tool_tag=presbmit //ci:presubmit -- --skip-bazel-tests --dirty \
             --dangerously-skip-pnpm-lockfile-validation --overwrite && \
             echo "::endgroup::"
         env:
@@ -105,7 +105,7 @@ jobs:
         # we can run this dirty since the next run will --overwrite anyway
         run: |
          ./.github/workflows/bootstrap_bazel_remote_cache.sh
-         bazel run //ci:presubmit -- \
+         bazel run --tool_tag=presubmit //ci:presubmit -- \
          --skip-bazel-tests \
          --dangerously-skip-pnpm-lockfile-validation --dirty
         env:

--- a/ci/presubmit.ts
+++ b/ci/presubmit.ts
@@ -130,7 +130,13 @@ const cmd = new Command('presubmit')
 			child_process
 				.spawn(
 					'bazel',
-					['run', '//:gazelle-update-repos', '--', '-strict'],
+					[
+						'run',
+						'--tool_tag=presubmit',
+						'//:gazelle-update-repos',
+						'--',
+						'-strict',
+					],
 					{
 						cwd,
 						stdio: 'inherit',
@@ -149,10 +155,20 @@ const cmd = new Command('presubmit')
 
 		await new Promise<void>((ok, error) =>
 			child_process
-				.spawn('bazel', ['run', '//:gazelle', '--', '--strict'], {
-					cwd,
-					stdio: 'inherit',
-				})
+				.spawn(
+					'bazel',
+					[
+						'run',
+						'//:gazelle',
+						'--tool_tag=presubmit',
+						'--',
+						'--strict',
+					],
+					{
+						cwd,
+						stdio: 'inherit',
+					}
+				)
 				.on('close', code =>
 					code == 0
 						? ok()


### PR DESCRIPTION
Add --tool_tag tracking to presubmit.

See: https://bazel.build/reference/command-line-reference#flag--tool_tag
