### PR TITLE
sh/bin: bazel alias for dlv, gopackagesdriver, staticcheck, goimports and go

### DIFF
--- a/.vscode/testing/BUILD.bazel
+++ b/.vscode/testing/BUILD.bazel
@@ -5,17 +5,17 @@ sh_test(
 		"@bazel_tools//tools/bash/runfiles",
 	],
 	data = [
-		"@io_bazel_rules_go//go",
-		"@io_bazel_rules_go//go/tools/gopackagesdriver",
-		"@org_golang_x_tools//cmd/goimports",
-		"@co_honnef_go_tools//cmd/staticcheck",
-		"@com_github_go_delve_delve//cmd/dlv"
+		"//sh/bin:go",
+		"//sh/bin:gopackagesdriver",
+		"//sh/bin:goimports",
+		"//sh/bin:staticcheck",
+		"//sh/bin:dlv"
 	],
 	env = {
-		"GO_BINARY": "$(rlocationpath @io_bazel_rules_go//go)",
-		"GOPACKAGESDRIVER_BINARY": "$(rlocationpath @io_bazel_rules_go//go/tools/gopackagesdriver)",
-		"GOIMPORTS_BINARY": "$(rlocationpath @org_golang_x_tools//cmd/goimports)",
-		"STATICCHECK_BINARY": "$(rlocationpath @co_honnef_go_tools//cmd/staticcheck)",
-		"DLV_BINARY": "$(rlocationpath @com_github_go_delve_delve//cmd/dlv)"
+		"GO_BINARY": "$(rlocationpath //sh/bin:go)",
+		"GOPACKAGESDRIVER_BINARY": "$(rlocationpath //sh/bin:gopackagesdriver)",
+		"GOIMPORTS_BINARY": "$(rlocationpath //sh/bin:goimports)",
+		"STATICCHECK_BINARY": "$(rlocationpath //sh/bin:staticcheck)",
+		"DLV_BINARY": "$(rlocationpath //sh/bin:dlv)"
 	}
 )

--- a/sh/bin/BUILD.bazel
+++ b/sh/bin/BUILD.bazel
@@ -1,0 +1,26 @@
+package(default_visibility = ["//:__subpackages__"])
+
+alias(
+	name = "dlv",
+	actual = "@com_github_go_delve_delve//cmd/dlv",
+)
+
+alias(
+	name = "go",
+	actual = "@io_bazel_rules_go//go"
+)
+
+alias(
+	name = "goimports",
+	actual = "@org_golang_x_tools//cmd/goimports"
+)
+
+alias(
+	name = "gopackagesdriver",
+	actual = "@io_bazel_rules_go//go/tools/gopackagesdriver"
+)
+
+alias(
+	name = "staticcheck",
+	actual = "@co_honnef_go_tools//cmd/staticcheck"
+)

--- a/sh/bin/dlv
+++ b/sh/bin/dlv
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" @com_github_go_delve_delve//cmd/dlv "${@}"
+"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" //sh/bin:dlv "${@}"

--- a/sh/bin/go
+++ b/sh/bin/go
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" @io_bazel_rules_go//go "${@}"
+"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" //sh/bin:go "${@}"

--- a/sh/bin/goimports
+++ b/sh/bin/goimports
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" @org_golang_x_tools//cmd/goimports "${@}"
+"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" //sh/bin:goimports "${@}"

--- a/sh/bin/gopackagesdriver
+++ b/sh/bin/gopackagesdriver
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"
+"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" //sh/bin:gopackagesdriver "${@}"

--- a/sh/bin/staticcheck
+++ b/sh/bin/staticcheck
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" @co_honnef_go_tools//cmd/staticcheck "${@}"
+"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" //sh/bin:staticcheck "${@}"


### PR DESCRIPTION
sh/bin: bazel alias for dlv, gopackagesdriver, staticcheck, goimports and go

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/4436).
* #4425
* #4437
* __->__ #4436