### PR TITLE
Back out "Back out "ci/presubmit: use local Go binary version to ensure syncronicity.""

### DIFF
--- a/ci/BUILD.bazel
+++ b/ci/BUILD.bazel
@@ -25,8 +25,11 @@ jest_test(
 
 js_binary(
     name = "presubmit",
-    data = [":ci"],
+    data = [":ci", "//sh/bin:go"],
     entry_point = "presubmit.js",
+	env = {
+		"GO_BINARY_LOCATION": "$(rlocationpath //sh/bin:go)"
+	}
 )
 
 js_binary(

--- a/ci/presubmit.ts
+++ b/ci/presubmit.ts
@@ -111,10 +111,23 @@ const cmd = new Command('presubmit')
 		// for all files at once in a genrule.
 		await new Promise<void>((ok, error) =>
 			child_process
-				.spawn('go', ['mod', 'tidy'], {
-					cwd,
-					stdio: 'inherit',
-				})
+				.spawn(
+					'bazel',
+					[
+						'run',
+						'--tool_tag=presubmit',
+						// it would be better to use the binary directly in our
+						// runfiles, but then the go binary itself has runfiles issues
+						// for some reason...
+						'//sh/bin:go',
+						'mod',
+						'tidy',
+					],
+					{
+						cwd,
+						stdio: 'inherit',
+					}
+				)
 				.on('close', code =>
 					code == 0
 						? ok()


### PR DESCRIPTION
Back out "Back out "ci/presubmit: use local Go binary version to ensure syncronicity.""

Original commit changeset: 30360d4a74cd
