### PR TITLE
Back out "Back out "ci/presubmit: use local Go binary version to ensure syncronicity.""

### DIFF
--- a/ci/BUILD.bazel
+++ b/ci/BUILD.bazel
@@ -25,8 +25,11 @@ jest_test(
 
 js_binary(
     name = "presubmit",
-    data = [":ci"],
+    data = [":ci", "//sh/bin:go"],
     entry_point = "presubmit.js",
+	env = {
+		"GO_BINARY_LOCATION": "$(rlocationpath //sh/bin:go)"
+	}
 )
 
 js_binary(

--- a/ci/presubmit.ts
+++ b/ci/presubmit.ts
@@ -1,5 +1,6 @@
 import child_process from 'node:child_process';
 
+import { runfiles } from '@bazel/runfiles';
 import { Command } from '@commander-js/extra-typings';
 import * as Bazel from 'ci/bazel';
 import { Command as WorkflowCommand } from 'ts/github/actions';
@@ -111,10 +112,16 @@ const cmd = new Command('presubmit')
 		// for all files at once in a genrule.
 		await new Promise<void>((ok, error) =>
 			child_process
-				.spawn('go', ['mod', 'tidy'], {
-					cwd,
-					stdio: 'inherit',
-				})
+				.spawn(
+					runfiles.resolveWorkspaceRelative(
+						process.env['GO_BINARY_LOCATION']!
+					),
+					['mod', 'tidy'],
+					{
+						cwd,
+						stdio: 'inherit',
+					}
+				)
 				.on('close', code =>
 					code == 0
 						? ok()


### PR DESCRIPTION
Back out "Back out "ci/presubmit: use local Go binary version to ensure syncronicity.""

Original commit changeset: 30360d4a74cd

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/4438).
* #4425
* __->__ #4438