### PR TITLE
project/zemn.me: introduce UUIDs for events for permalinks and utilize those permalinks in the site.

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"@pulumi/command": "4.5.0",
 		"@react-spring/rafz": "9.7.3",
 		"@types/bcryptjs": "2.4.6",
+		"@types/memoizee": "^0.4.11",
 		"@types/seedrandom": "3.0.8",
 		"csstype": "3.1.3",
 		"devtools-protocol": "0.0.1245094",
@@ -114,6 +115,7 @@
 		"eslint-plugin-mdx": "3.0.0",
 		"glob-promise": "6.0.5",
 		"json-schema-to-typescript": "13.1.2",
+		"memoizee": "^0.4.15",
 		"npm": "10.3.0",
 		"pnpm": "^8.0.0",
 		"seedrandom": "3.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   '@types/bcryptjs':
     specifier: 2.4.6
     version: 2.4.6
+  '@types/memoizee':
+    specifier: ^0.4.11
+    version: 0.4.11
   '@types/seedrandom':
     specifier: 3.0.8
     version: 3.0.8
@@ -41,6 +44,9 @@ dependencies:
   json-schema-to-typescript:
     specifier: 13.1.2
     version: 13.1.2
+  memoizee:
+    specifier: ^0.4.15
+    version: 0.4.15
   npm:
     specifier: 10.3.0
     version: 10.3.0
@@ -6803,6 +6809,10 @@ packages:
     resolution: {integrity: sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==}
     dependencies:
       '@types/unist': 3.0.2
+    dev: false
+
+  /@types/memoizee@0.4.11:
+    resolution: {integrity: sha512-2gyorIBZu8GoDr9pYjROkxWWcFtHCquF7TVbN2I+/OvgZhnIGQS0vX5KJz4lXNKb8XOSfxFOSG5OLru1ESqLUg==}
     dev: false
 
   /@types/mime@3.0.4:

--- a/project/zemn.me/bio/bio.ts
+++ b/project/zemn.me/bio/bio.ts
@@ -46,6 +46,7 @@ export interface Employment {
 }
 
 export interface Event {
+	id: string;
 	readonly date: Date;
 	readonly description?: Text;
 	readonly tags?: readonly Tag[];
@@ -113,6 +114,7 @@ export const Bio = {
 	timeline: [
 		// BEGIN TOOL ASSISTED SORT
 		{
+			id: 'bda2ee54-67ba-4650-887c-78240143a825',
 			date: date(23, 'nov', 2022),
 			description: en`Google research; exploit to remotely take over VSCode and any attached cloud systems. CVE-2022-41034, GHSA-pw56-c55x-cm9m`,
 			tags: [security, disclosure],
@@ -121,6 +123,7 @@ export const Bio = {
 		},
 
 		{
+			id: '93de4b1d-0501-4839-b735-66ff8db48aca',
 			date: date(14, 'jan', 2019),
 			description: en`react helper bindings for d3`,
 			priority: 6,
@@ -129,6 +132,7 @@ export const Bio = {
 			url: url`https://github.com/Zemnmez/reactive-d3`,
 		},
 		{
+			id: '73ee7f25-a947-4d86-8efe-0ba52c105b94',
 			date: date(18, 'feb', 2017),
 			description: en`musings on the evolution of design`,
 			tags: [writing],
@@ -136,6 +140,7 @@ export const Bio = {
 			url: url`https://medium.com/@Zemnmez/design-evolves-by-constraint-f2d87697d25e`,
 		},
 		{
+			id: 'b0e4bf15-c630-4804-b1db-713cd79d4633',
 			date: date(3, 'jan', 2016),
 			description: en`minimal reactive d3.js resistor colour code calculator`,
 			priority: 6,
@@ -144,6 +149,7 @@ export const Bio = {
 			url: url`http://r.no.ms`,
 		},
 		{
+			id: 'a3363960-8fa3-4c5d-b434-c99d4c8b5519',
 			date: date(1, 'apr', 2011),
 			description: en`London Real Time Hackathon`,
 			priority: 5,
@@ -152,6 +158,7 @@ export const Bio = {
 			url: url`https://web.archive.org/web/20121113024249/http:%2F%2Flondonrealtime.co.uk/`,
 		},
 		{
+			id: 'faf30607-fb52-44b7-a331-13d2abf3ffa7',
 			date: date(25, 'feb', 2020),
 			title: en`SVGShot`,
 			url: url`https://github.com/Zemnmez/svgshot`,
@@ -159,6 +166,7 @@ export const Bio = {
 			tags: [typescript, code],
 		},
 		{
+			id: '299714d5-7580-4889-94b2-0c71b2e1ca9c',
 			date: date(1, 'sep', 2011),
 			description: en`Volunteer role at once largest trading website in the Steam community. Worked on administration of high-profile trades & scams`,
 			until: date(1, 'sep', 2014),
@@ -167,6 +175,7 @@ export const Bio = {
 			title: en`Sr. Admin, TF2Outpost`,
 		},
 		{
+			id: '10750828-785a-491e-bd00-dad3c886fd01',
 			date: date(5, 'aug', 2011),
 			description: en`Rewired State: Parliament`,
 			priority: 5,
@@ -175,6 +184,7 @@ export const Bio = {
 			url: url`https://web.archive.org/web/20121105174535/http:%2F%2Frewiredstate.org:80/blog/2011/11/press-release-for-rewired-state-parliament`,
 		},
 		{
+			id: '963e6a0a-d279-4838-a2d6-2445a0ec97e4',
 			date: date(1, 'feb', 2011),
 			description: en`Young Rewired State 2011`,
 			priority: 5,
@@ -183,12 +193,14 @@ export const Bio = {
 			url: url`https://web.archive.org/web/20120306190316/http:%2F%2Fyoungrewiredstate.org/2011-08/cant-vote-but-can-put-a-wind-in-governments-sails/`,
 		},
 		{
+			id: 'e4ad85a6-fee3-4824-aadc-3963ef30dcb9',
 			date: date(1, 'feb', 2020),
 			title: en`HackFortress Shmoocon 2020 Champions`,
 			tags: [accolade, security, gaming],
 			description: en`defended title for hybrid gaming ctf`,
 		},
 		{
+			id: 'befbb9a3-5499-4f45-b251-fa899c178b4d',
 			date: date(2, 'aug', 2019),
 			title: en`If CORS is just a header, why don’t attackers just ignore it?`,
 			url: url`https://medium.com/@Zemnmez/if-cors-is-just-a-header-why-dont-attackers-just-ignore-it-63e57c323cef?source=your_stories_page---------------------------`,
@@ -196,11 +208,13 @@ export const Bio = {
 			tags: [writing, security],
 		},
 		{
+			id: '9195a7e3-b02f-4eb5-8b47-6ae7a9900800',
 			date: date(9, 'aug', 2020),
 			title: en`HackFortress DefCon 2020 Champions`,
 			tags: [accolade, security],
 		},
 		{
+			id: '169b8cda-5634-49fd-9f96-cce5566bb545',
 			date: date(1, 'may', 2012),
 			description: en`full stack freelance work building MVPs for London startups and wrangling data for hackathons`,
 			until: date(1, 'may', 2014),
@@ -209,6 +223,7 @@ export const Bio = {
 			title: en`Software Engineer, Consultant`,
 		},
 		{
+			id: 'ace0faea-313d-49f0-bbb0-9ab908fb956a',
 			date: date(7, 'jan', 2019),
 			description: en`react based personal website for 2019`,
 			priority: 6,
@@ -217,6 +232,7 @@ export const Bio = {
 			url: url`https://github.com/Zemnmez/linear`,
 		},
 		{
+			id: '763a0f63-bf83-4fef-9693-6cf89804f583',
 			date: date(19, 'oct', 2020),
 			title: en`Typescript Union Merging`,
 			description: en`Using interface merging to write somewhat decentralised Redux actions`,
@@ -224,6 +240,7 @@ export const Bio = {
 			tags: [code, typescript, writing],
 		},
 		{
+			id: '150422cc-71bc-444e-bfdb-f16453f4d70a',
 			title: en`CSVPretty`,
 			url: url`https://github.com/Zemnmez/csvpretty`,
 			description: en`typescript pretty printer for the CSV format`,
@@ -231,6 +248,7 @@ export const Bio = {
 			tags: [golang, code],
 		},
 		{
+			id: '214f6425-d041-4d81-824e-737d6b3cd2df',
 			date: date(8, 'nov', 2011),
 			description: en`Interview on National Hack the Government Day prize (dutch)`,
 			priority: 5,
@@ -239,6 +257,7 @@ export const Bio = {
 			url: url`http://www.denieuwereporter.nl/2011/11/mozfest-rewired-state-geeft-jonge-programmeurs-een-kans/`,
 		},
 		{
+			id: '6b7e92fb-bb5d-40ec-8210-2e4a28e54e66',
 			date: date(1, 'apr', 2011),
 			description: en`National Hack the Government Day 2011`,
 			priority: 5,
@@ -247,6 +266,7 @@ export const Bio = {
 			url: url`https://www.theguardian.com/info/developer-blog/2011/apr/05/national-hack-the-government-day-2011`,
 		},
 		{
+			id: '08e89c21-4532-4a6d-af34-39909e30fe82',
 			date: date(11, 'apr', 2020),
 			title: en`do-sync`,
 			description: en`Async to sync library for encapsulated javascript macros`,
@@ -254,6 +274,7 @@ export const Bio = {
 			tags: [code, typescript],
 		},
 		{
+			id: '7196a47d-d9f9-442f-84dd-31e2fcf76e77',
 			date: date(16, 'jun', 2019),
 			title: en`react-oauth2-hook`,
 			url: url`https://github.com/Zemnmez/react-oauth2-hook`,
@@ -261,6 +282,7 @@ export const Bio = {
 			tags: [react, code, security, typescript],
 		},
 		{
+			id: '0943b965-3c14-4bb9-b1c4-57a3a5135d89',
 			date: date(1, 'may', 2020),
 			title: en`Why We don't we have UIs like the ones in Neon Genesis`,
 			description: en`Exploration of how rendering hardware has affected UI design`,
@@ -268,6 +290,7 @@ export const Bio = {
 			tags: [writing, design],
 		},
 		{
+			id: 'd3c0644d-82a4-49cb-ae5e-a75d36779232',
 			date: date(4, 'jul', 2017),
 			description: en`musings on go-specific security gotchas`,
 			priority: 5,
@@ -276,6 +299,7 @@ export const Bio = {
 			url: url`https://www.infoq.com/presentations/go-security`,
 		},
 		{
+			id: 'f775df0d-070c-4a96-accc-5f6b4fd60e71',
 			date: date(1, 'mar', 2012),
 			description: en`charity focused on teaching code literacy. Ran and participated in hackathons for good causes. Taught software engineering to young people`,
 			until: date(1, 'mar', 2015),
@@ -284,6 +308,7 @@ export const Bio = {
 			title: en`Developer, Rewired State`,
 		},
 		{
+			id: '886812e0-cc54-40a8-88ef-a23c1ae35390',
 			date: date(23, 'nov', 2017),
 			description: en`talk at owasp about critical uk tax system flaw in obfuscated system and the 57 day trek to get it fixed`,
 			priority: 6,
@@ -292,6 +317,7 @@ export const Bio = {
 			url: url`https://twitter.com/zemnmez/status/933847040198574080`,
 		},
 		{
+			id: '12939520-a1eb-420d-bd2f-3fbe0922d66d',
 			date: date(25, 'jan', 2016),
 			description: en`unauthorized remote shutdown of Buffalo-made network attached storage devices`,
 			priority: 6,
@@ -300,6 +326,7 @@ export const Bio = {
 			url: url`https://packetstormsecurity.com/files/135368`,
 		},
 		{
+			id: '9fd25be4-62d1-4b48-ab9f-4c3357357674',
 			date: date(22, 'apr', 2014),
 			description: en`unique developer granted cosmetic item for the video game Team Fortress 2 granted for security issues allowing movement millions of dollars of virtual items between arbitrary accounts via account takeover`,
 			priority: 6.5,
@@ -308,6 +335,7 @@ export const Bio = {
 			url: url`http://steamcommunity.com/id/both/inventory/#440_2_4818206214`,
 		},
 		{
+			id: '4a091ea1-6e55-424e-9bdf-59fbd7fcb9d6',
 			date: date(14, 'dec', 2015),
 			description: en`unique developer granted cosmetic item for the video game Team Fortress 2 granted for security issue allowing decryption of all Steam traffic`,
 			priority: 6.5,
@@ -316,6 +344,7 @@ export const Bio = {
 			url: url`https://steamcommunity.com/id/both/inventory/#440_2_4398163918`,
 		},
 		{
+			id: '1bb3ddd1-bdab-4eca-97e2-5e2b50323136',
 			date: date(20, 'jan', 2019),
 			description: en`hybrid ctf / esports competition winners`,
 			priority: 6,
@@ -324,6 +353,7 @@ export const Bio = {
 			url: url`https://twitter.com/tf2shmoo/status/1086785642514796544`,
 		},
 		{
+			id: 'a0113940-008d-45e0-a279-ad3d417c7171',
 			date: date(15, 'dec', 2018),
 			description: en`Quick article on the security of modern desktop web applications`,
 			priority: 7,
@@ -332,6 +362,7 @@ export const Bio = {
 			url: url`https://medium.com/@Zemnmez/%C3%BCbersicht-remote-code-execution-spotify-takeover-a5f6fd6809d0`,
 		},
 		{
+			id: 'a0b8e856-400c-4b85-9407-4bbaa8e57783',
 			date: date(12, 'aug', 2019),
 			priority: 6,
 			tags: [security, gaming, accolade],
@@ -339,6 +370,7 @@ export const Bio = {
 			url: url`https://twitter.com/tf2shmoo/status/1028462663368507392`,
 		},
 		{
+			id: '214fcf06-69b5-4eb2-a5d3-882e13c42071',
 			date: date(19, 'oct', 2015),
 			description: en`unique developer granted cosmetic item for the video game Team Fortress 2 granted for security issues allowing remote access to computers running the video game`,
 			priority: 7,
@@ -347,6 +379,7 @@ export const Bio = {
 			url: url`https://steamcommunity.com/id/both/inventory/#440_2_4228772424`,
 		},
 		{
+			id: '3ab05545-8d7b-47d7-9dca-6f5582a806d8',
 			date: date(11, 'may', 2016),
 			description: en`XSS in Mr Robot official site`,
 			priority: 6,
@@ -355,6 +388,7 @@ export const Bio = {
 			url: url`https://www.forbes.com/sites/thomasbrewster/2016/05/11/flaw-in-mr-robot-website-allowed-facebook-attack/#747437ef6bed`,
 		},
 		{
+			id: '08426500-28e9-4398-8156-102df7dda51e',
 			date: date(24, 'jan', 2016),
 			description: en`Host based account hijack attack on php-openid`,
 			priority: 6,
@@ -363,6 +397,7 @@ export const Bio = {
 			url: url`https://nvd.nist.gov/vuln/detail/CVE-2016-2049`,
 		},
 		{
+			id: 'aab4593b-9c81-444e-b607-e6f02b812f14',
 			date: date(16, 'may', 2016),
 			description: en`code execution in official Mr Robot site`,
 			priority: 7,
@@ -371,6 +406,7 @@ export const Bio = {
 			url: url`https://www.forbes.com/sites/thomasbrewster/2016/05/16/mr-robot-imagetragick-usa-network-wide-open-to-hackers/#7d49f6f66d77`,
 		},
 		{
+			id: '24896136-580f-460b-a1d3-56f5ba92ae17',
 			date: date(1, 'jan', 2013),
 			description: en`international chemistry challenge`,
 			priority: 6,
@@ -378,6 +414,7 @@ export const Bio = {
 			title: en`7th place Cambridge Chemistry Challenge (C3L6)`,
 		},
 		{
+			id: '74086941-7c37-4f3e-af9b-4cc8e8bbc749',
 			date: date(1, 'jan', 2014),
 			description: en`international chemistry challenge`,
 			priority: 5,
@@ -385,6 +422,7 @@ export const Bio = {
 			title: en`5th place, Cambridge Chemistry Challenge (C3L6)`,
 		},
 		{
+			id: '7aa346f4-31b3-41fa-9844-58a4be83b050',
 			date: date(2, 'sep', 2018),
 			title: en`I hacked video games like 300 times and all I got was this stupid talk`,
 			tags: [talk, gaming, security],
@@ -392,6 +430,7 @@ export const Bio = {
 			url: url`https://www.youtube.com/watch?v=NjMMK-FkTW4&list=PLFqM5L7fs0mO3O3-BBZfA-sHeT86Gesd8&index=15&`,
 		},
 		{
+			id: '91956c2c-ebb6-45a1-aca0-065c3cc4b003',
 			date: date(5, 'sep', 2018),
 			title: en`Cross-site information assertion leak via Content Security Policy`,
 			url: url`https://hackerone.com/reports/16910`,
@@ -399,6 +438,7 @@ export const Bio = {
 			tags: [security, disclosure],
 		},
 		{
+			id: 'f6bfd6fd-a84f-449d-90f9-218a55f22c35',
 			date: date(7, 'jul', 2014),
 			description: en`exploit using content security policy 1 to steal data on the web`,
 			priority: 9,
@@ -407,6 +447,7 @@ export const Bio = {
 			url: url`http://archive.is/UXD8j`,
 		},
 		{
+			id: 'd4b51ac9-107c-4e83-b07f-0cffa34255f6',
 			date: date(27, 'apr', 2016),
 			description: en`padding oracle based decryption of Steam traffic`,
 			priority: 7,
@@ -415,6 +456,7 @@ export const Bio = {
 			url: url`https://threatpost.com/steam-patches-broken-crypto-in-wake-of-replay-padding-oracle-attacks/117691/`,
 		},
 		{
+			id: 'fdee36cb-45fa-4d94-8575-e3e19ac2ed09',
 			date: date(7, 'jan', 2019),
 			description: en`vulnerability to remotely access Steam users' computers`,
 			priority: 8,
@@ -423,6 +465,7 @@ export const Bio = {
 			url: url`https://hackerone.com/reports/409850`,
 		},
 		{
+			id: '440b0daa-bb07-44e0-81a6-7a51eda0d9b5',
 			date: date(7, 'jan', 2019),
 			description: en`XSS to RCE on Steam`,
 			tags: [security, writing, disclosure],
@@ -430,6 +473,7 @@ export const Bio = {
 			url: url`//hackerone.com/reports/409850`,
 		},
 		{
+			id: '98835628-87ee-435f-bfbf-4d44540b0b94',
 			date: date(8, 'jan', 2019),
 			description: en`news coverage of steam rce`,
 			priority: 7,
@@ -438,6 +482,7 @@ export const Bio = {
 			url: url`https://www.forbes.com/sites/thomasbrewster/2019/01/08/7500-steam-weakness-let-hackers-take-remote-control-of-gamers-pcs`,
 		},
 		{
+			id: '1028217a-3167-44ce-af82-7e0b23847471',
 			date: date(17, 'may', 2019),
 			title: en`Full Steam Ahead: Remotely Executing Code in Modern Desktop Applications`,
 			description: en`technical talk at offensive AppSec conference Infiltrate summarising through example research into hybrid web / desktop application security`,
@@ -445,6 +490,7 @@ export const Bio = {
 			url: url`https://vimeo.com/335206831`,
 		},
 		{
+			id: '9160d646-f61a-4dd2-9533-84d176e65300',
 			date: date(8, 'sep', 2017),
 			description: en`news post on manipulation of UK tax data`,
 			priority: 6,
@@ -453,6 +499,7 @@ export const Bio = {
 			url: url`http://www.bbc.co.uk/news/technology-41188008`,
 		},
 		{
+			id: '0dd06d43-6abe-4cf5-ac94-c2d8d66e9451',
 			date: date(4, 'dec', 2019),
 			title: en`UK Government Vulnerability Disclosure Initiative`,
 			url: url`https://www.ncsc.gov.uk/information/vulnerability-reporting`,
@@ -460,6 +507,7 @@ export const Bio = {
 			tags: [work, security],
 		},
 		{
+			id: 'a3777d0d-e747-4bbd-aea5-33c06d61230e',
 			date: date(22, 'jan', 2018),
 			description: en`advisory position. Provided expertise to UK cyber advisory / defence group on Go and building security analysis systems. Launched world's first government-wide responsible disclosure program.`,
 			until: 'ongoing',
@@ -468,6 +516,7 @@ export const Bio = {
 			title: en`Application Security Engineer, UK National Cyber Security Centre`,
 		},
 		{
+			id: 'bbd55200-f16a-4193-b704-ced4bf79b9d5',
 			date: date(23, 'jul', 2020),
 			title: en`Senior Information Security Engineer, Google ISE hardening`,
 			description: en`Automated security mitigation, detection and refactoring using compiler technology (“langsec”), SDKs and DSLs (“hardening”) on TypeScript and Java. Google-wide mitigations for Log4Shell, XSS, deserialization attacks. Product security review and design, Google Ads (“FLOC”, “FLEDGE”), Google Cloud, Google's IDE (“Cider”). Research including critical disclosures such as CVE-2022-41034.`,
@@ -475,6 +524,7 @@ export const Bio = {
 			until: date(17, 'mar', 2023), // i dont remember the exact date
 		},
 		{
+			id: '3c32b4fc-94a6-42da-ad19-e77669e63f0e',
 			date: date(22, 'jan', 2018),
 			priority: 8,
 			tags: [gaming, security, accolade],
@@ -483,6 +533,7 @@ export const Bio = {
 			description: en`for my work at Twitch, and on responsible disclosure`,
 		},
 		{
+			id: '6186a21e-a04f-455f-9fc1-776b63d1ebbb',
 			date: date(8, 'sep', 2017),
 			description: en`vulnerability allowing manipulation of UK tax system`,
 			priority: 8,
@@ -491,6 +542,7 @@ export const Bio = {
 			url: url`https://medium.com/@Zemnmez/how-to-hack-the-uk-tax-system-i-guess-3e84b70f8b`,
 		},
 		{
+			id: 'c22f92e7-570c-4059-8f76-52af78214286',
 			date: date(11, 'jul', 2019),
 			title: en`National Cyber Security Centre 'Turing' challenge coin`,
 			priority: 5,
@@ -499,6 +551,7 @@ export const Bio = {
 			description: en`award for my work on UK government vulnerability disclosure policy and my responsible disclosure of vulnerabilities in the UK tax system.`,
 		},
 		{
+			id: '0bb2bc73-56d9-42ee-bf2e-8e581f885d97',
 			date: date(1, 'sep', 2014),
 			description: en`first security engineer at the video game streaming website. Designed security architecture for flagship projects including bits, the Twitch API, extensions and Twitch's OIDC / OAuth AuthN/Z systems. Created and defined security relationships and processes. Built Go security static analysis system, security frameworks and libraries`,
 			until: date(11, 'jul', 2020),
@@ -508,6 +561,7 @@ export const Bio = {
 			url: url`https://twitch.tv`,
 		},
 		{
+			id: '3d6ca0b4-febc-44ea-bbd1-1b01cf95b1ec',
 			date: date(26, 'dec', 2020),
 			title: en`How to Hack Apple ID`,
 			url: url`https://zemnmez.medium.com/how-to-hack-apple-id-f3cc9b483a41`,
@@ -515,6 +569,7 @@ export const Bio = {
 			description: en`bypassing cutting-edge web security techniques to hack Apple ID`,
 		},
 		{
+			id: '194784f2-4607-4bff-b96f-56f2e1a29b6f',
 			date: date(13, 'aug', 2023),
 			title: en`Def Con Black Badge`,
 			tags: [accolade, security],
@@ -522,6 +577,7 @@ export const Bio = {
 			url: url`https://defcon.org/html/links/dc-black-badge.html#tab-31`,
 		},
 		{
+			id: '957be17b-5e69-4343-ac27-3697aeee2746',
 			date: date(24, 'jul', 2021),
 			title: en`Monorepo`,
 			tags: [typescript, rust, react, software, code],
@@ -529,6 +585,7 @@ export const Bio = {
 			url: url`https://github.com/zemn-me/monorepo`,
 		},
 		{
+			id: 'f85c3e85-4f0e-49cf-98cf-7042aa91a2c0',
 			date: date(6, 'mar', 2023),
 			title: en`Login CSRF, VTubeStudio`,
 			tags: [security, disclosure],
@@ -536,6 +593,7 @@ export const Bio = {
 			url: url`https://twitter.com/VTubeStudio/status/1632733713891983360`,
 		},
 		{
+			id: '9d204846-266d-4dc4-be46-e055b139fdba',
 			date: date(11, 'aug', 2023),
 			title: en`Visual Studio Code is why I have (Workspace) Trust issues`,
 			tags: [security],
@@ -543,51 +601,60 @@ export const Bio = {
 			url: url`https://media.defcon.org/DEF%20CON%2031/DEF%20CON%2031%20presentations/Thomas%20Chauchefoin%20Paul%20Gerste%20-%20Visual%20Studio%20Code%20is%20why%20I%20have%20%28Workspace%29%20Trust%20issues.pdf`,
 		},
 		{
+			id: 'e76c6572-d156-4f91-994d-b891eba4b771',
 			date: date(1, 'nov', 2021),
 			title: en`Relocated to San Francisco from London.`,
 		},
 		{
+			id: '1a8b8ecc-784e-4fcc-b008-1b8532942a34',
 			date: date(12, 'aug', 2023),
 			title: en`Def Con 31 Hack Fortress Champions`,
 			description: en`hybrid ctf / esports competition winners.`,
 			url: url`https://twitter.com/tf2shmoo/status/1690538453669429248`,
 		},
 		{
+			id: '41b9fa28-bffa-4506-8e86-1bc3b2880c2f',
 			date: date(9, 'apr', 2019),
 			title: en`IE 11 command switch injection`,
 			description: en`in IE11, programs on the user's computer could be launched with arbitrary arguments by running executing the scheme in an iframe. CVE-2019-0764`,
 			url: url`https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2019-0764`,
 		},
 		{
+			id: 'db098b2c-fac0-4033-9911-9d6187812b19',
 			date: date(25, 'nov', 2019),
 			description: en`in Google Chrome, Blink, or Chromium, it was possible to bypass cross-origin restrictions by causing a refresh of a failed cross-origin request. CVE-2019-13664`,
 			title: en`Chromium cross-origin bypass`,
 			url: url`https://nvd.nist.gov/vuln/detail/CVE-2019-13664`,
 		},
 		{
+			id: '1aced039-3215-472f-aac6-612e5a0a0f16',
 			date: date(23, 'oct', 2023),
 			title: en`crypto-js PBKDF2 1,000 times weaker than specified in 1993 and 1.3M times weaker than current standard`,
 			description: en`Vulnerability in second most popular Javascript cryptography library allowing forgery of digital signatures. CVE-2023-46133`,
 			url: url`https://github.com/advisories/GHSA-xwcq-pm8m-c4vf`,
 		},
 		{
+			id: '4ef84524-9e7a-4b2c-a300-2c679424b116',
 			date: date(23, 'oct', 2023),
 			title: en`crypto-es PBKDF2 1,000 times weaker than specified in 1993 and 1.3M times weaker than current standard`,
 			description: en`Vulnerability in maintained fork of most popular Javascript cryptography library allowing forgery of digital signatures. CVE-2023-46233`,
 			url: url`https://github.com/advisories/GHSA-mpj8-q39x-wq5h`,
 		},
 		{
+			id: '3d14e688-452b-4903-9634-c4af5a434dea',
 			date: date(1, 'jul', 2021),
 			title: en`Apple Hall of Fame`,
 			description: en`For major security issue covered in 'How to Hack Apple ID'.`,
 			url: url`https://support.apple.com/en-gb/HT213636#:~:text=Thomas%20Shadwell%20(%40zemnmez)%20of%20Google`,
 		},
 		{
+			id: '94c6577b-372f-4842-b2c5-1438f16b2eab',
 			date: date(28, 'nov', 2023),
 			title: en`Member of Technical Staff, Security Product and Platform (PROP), OpenAI`,
 			tags: [software, security, work],
 		},
 		{
+			id: '741b6fc1-5c5b-4319-aa9b-36f4b88d7f9a',
 			date: date(13, 'jan', 2024),
 			title: en`HackFortress Shmoocon 2024 Champions`,
 			description: en`Won my favorite CTF at the penultimate Shmoocon.`,

--- a/project/zemn.me/bio/testing/BUILD.bazel
+++ b/project/zemn.me/bio/testing/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//ts:rules.bzl", "ts_project", "jest_test")
+
+ts_project(
+	name = "ts",
+	deps = [
+		"//project/zemn.me/bio",
+		"//:node_modules/@types/jest"
+	]
+)
+
+jest_test(
+	name = "tests",
+	srcs = [ "ensure_ids_unique_test.js" ],
+	deps = [ ":ts" ]
+)

--- a/project/zemn.me/bio/testing/ensure_ids_unique_test.ts
+++ b/project/zemn.me/bio/testing/ensure_ids_unique_test.ts
@@ -1,0 +1,15 @@
+import { Bio } from 'project/zemn.me/bio/bio';
+
+test('ids must be unique', () => {
+	const ordered_ids = Bio.timeline.map(v => v.id);
+	const unique_ids = new Set(ordered_ids);
+
+	const sort = (a: string, b: string): number => {
+		if (a === b) return 0;
+		if (a < b) return -1;
+
+		return 1;
+	};
+
+	expect(ordered_ids.sort(sort)).toEqual([...unique_ids].sort(sort));
+});

--- a/project/zemn.me/components/BUILD.bazel
+++ b/project/zemn.me/components/BUILD.bazel
@@ -20,6 +20,9 @@ ts_project(
         "//project/zemn.me/bio",
 		"//:node_modules/next",
 		"//ts/iter",
-		"//:node_modules/@types/node"
+		"//:node_modules/@types/node",
+		"//:node_modules/memoizee",
+		"//:node_modules/@types/memoizee",
+		"//:node_modules/classnames"
     ],
 )

--- a/project/zemn.me/components/SectionLink/SectionLink.module.css
+++ b/project/zemn.me/components/SectionLink/SectionLink.module.css
@@ -1,0 +1,4 @@
+.sectionLink {
+	text-decoration: none;
+	font-size: small;
+}

--- a/project/zemn.me/components/SectionLink/SectionLink.tsx
+++ b/project/zemn.me/components/SectionLink/SectionLink.tsx
@@ -1,0 +1,17 @@
+import classNames from 'classnames';
+import Link, { LinkProps } from 'project/zemn.me/components/Link';
+import style from 'project/zemn.me/components/SectionLink/SectionLink.module.css';
+
+export const SectionLink: React.FC<LinkProps> = ({
+	className,
+	children,
+	...props
+}) => (
+	<Link
+		{...props}
+		className={classNames(style.sectionLink, className)}
+		rel="bookmark"
+	>
+		{children}
+	</Link>
+);

--- a/project/zemn.me/components/timeline/timeline.tsx
+++ b/project/zemn.me/components/timeline/timeline.tsx
@@ -1,8 +1,10 @@
 import Immutable from 'immutable';
+import memoizee from 'memoizee';
 import * as Bio from 'project/zemn.me/bio';
 import Link from 'project/zemn.me/components/Link';
+import { SectionLink } from 'project/zemn.me/components/SectionLink/SectionLink';
 import style from 'project/zemn.me/components/timeline/timeline.module.css';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import * as lang from 'ts/react/lang';
 
 interface MutableText {
@@ -25,6 +27,66 @@ const Text = Immutable.Record<MutableText>(
 
 function textToStringKey(t: ImmutableText): string {
 	return [t.get('language'), t.get('corpus')].join('-');
+}
+
+/**
+ * for a given set of strings, return the minimum number of
+ * characters we can choose from the list to ensure that
+ * each truncated string is unique.
+ */
+function shortestUniqueSample(strings: string[]): number {
+	const maxLength = strings.reduce(
+		(prev, current) => (current.length > prev ? current.length : prev),
+		-Infinity
+	);
+	for (let i = 1; i < maxLength; i++) {
+		const truncs = strings.map(v => v.slice(0, i));
+		if (truncs.length === [...new Set(truncs)].length) return i;
+	}
+
+	throw new Error('oops');
+}
+
+const eventIdPrefixCount = memoizee(() =>
+	shortestUniqueSample(Bio.Bio.timeline.map(v => v.id))
+);
+
+function shortIdForEvent(e: Bio.Event): string {
+	return e.id.slice(0, eventIdPrefixCount());
+}
+
+interface CorpusProps {
+	readonly children: lang.Text;
+}
+
+const sentanceTerminators = ['!', '.', '?', '…'];
+
+function needsFullStop(text: lang.Text): boolean {
+	if (text.locale.language !== 'en') return false;
+
+	if (sentanceTerminators.some(v => text.text.endsWith(v))) return false;
+
+	return true;
+}
+
+function fullStopIfNeeded(text: lang.Text): ReactElement | null {
+	if (needsFullStop(text)) return <>.</>;
+
+	return null;
+}
+
+/**
+ * Injects the victorian title-dot if needed.
+ * (it's a house-style thing I picked ages ago)
+ * @see https://www.reddit.com/r/AskLiteraryStudies/comments/n8mmno/why_do_we_no_longer_use_periodsfull_stops_in/gxtfw1y
+ */
+function Corpus({ children: text }: CorpusProps) {
+	return (
+		<>
+			{text.text}
+			{fullStopIfNeeded(text)}
+		</>
+	);
 }
 
 const numerals = [
@@ -90,11 +152,6 @@ function setManyMap<K, V>(
 	return v.set(key, v.get(key, Immutable.List<V>()).concat(value));
 }
 
-function addFullStopIfMissing(s: string) {
-	if (/[!?.]$/.test(s)) return s;
-	return s + '.';
-}
-
 function groupBy<T, Q>(
 	i: Iterable<T>,
 	select: (v: T) => Q
@@ -107,16 +164,19 @@ function groupBy<T, Q>(
 
 function Event({ event: e }: { readonly event: Bio.Event }) {
 	return (
-		<div className={style.event}>
-			<Link href={e.url?.toString()} lang={lang.get(e.title)}>
-				{lang.text(e.title)}
-			</Link>{' '}
+		<article className={style.event}>
+			<Link href={e.url?.toString()} id={e.id} lang={lang.get(e.title)}>
+				{e.title.text}
+				{/* this would be a <Corpus> but it looks ugly with the full stop inside the link. */}
+			</Link>
+			{fullStopIfNeeded(e.title)}{' '}
 			{e.description ? (
 				<span lang={lang.get(e.description)}>
-					{addFullStopIfMissing(lang.text(e.description))}
+					<Corpus>{e.description}</Corpus>
 				</span>
-			) : null}
-		</div>
+			) : null}{' '}
+			<SectionLink href={`#${e.id}`}>§{shortIdForEvent(e)}.</SectionLink>
+		</article>
 	);
 }
 
@@ -127,18 +187,12 @@ function Month({
 	readonly month: ImmutableText;
 	readonly events: Iterable<Bio.Event>;
 }) {
-	const locales = [...lang.useLocale()];
-	const locale = new Intl.Locale(
-		Intl.DateTimeFormat.supportedLocalesOf(locales)[0]
-	);
 	return (
 		<div className={style.month}>
 			<header className={style.monthName} lang={month.get('language')}>
-				{' '}
-				{month.get('corpus')}
-				{/* if we're typesetting in an english lanugage, do the victorian title-dot */}
-				{/* https://www.reddit.com/r/AskLiteraryStudies/comments/n8mmno/why_do_we_no_longer_use_periodsfull_stops_in/gxtfw1y */}
-				{locale.language === 'en' ? '.' : null}
+				<Corpus>
+					{lang.Text(month.get('language'), month.get('corpus'))}
+				</Corpus>
 			</header>
 			<div className={style.content}>
 				{[...events].map((e, i) => (

--- a/ts/react/lang/BUILD.bazel
+++ b/ts/react/lang/BUILD.bazel
@@ -15,5 +15,7 @@ ts_project(
         "//:node_modules/@types/react-dom",
         "//:node_modules/react",
         "//:node_modules/react-dom",
+        "//:node_modules/memoizee",
+		"//:node_modules/@types/memoizee"
     ],
 )

--- a/ts/react/lang/index.tsx
+++ b/ts/react/lang/index.tsx
@@ -1,3 +1,4 @@
+import memoizee from 'memoizee';
 import React from 'react';
 
 type Language = string;
@@ -7,6 +8,10 @@ export class TextType<L extends Language = Language, Text = string> {
 		public readonly language: L,
 		public readonly text: Text
 	) {}
+	private localeGetter = memoizee(() => new Intl.Locale(this.language));
+	get locale(): Intl.Locale {
+		return this.localeGetter();
+	}
 }
 
 export type Text<L extends Language = Language, Text = string> = TextType<


### PR DESCRIPTION
project/zemn.me: introduce UUIDs for events for permalinks and utilize those permalinks in the site.

Minor changes included:

- package.json & pnpm-lock.yml: add memoizee & @types/memoizee
- project/zemn.me/bio/bio.ts: add the IDs
changed project/zemn.me/components/timeline/timeline.tsx:  add section marks and be more zealous about having full stops at the end of fragments and sentences.
- ts/react/lang/index.tsx: add a memoized getter for the Intl.locale of the lang
- project/zemn.me/components/SectionLink/...: a variant of the <Link> tag that has rel="bookmark" and uses smaller text.
- project/zemn.me/bio/testing/...: tests to ensure that there aren't duplicate IDs

Fixes https://github.com/zemn-me/monorepo/issues/4444
