### PR TITLE
Add vscode-icons-team.vscode-icons to suggested extensions.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,12 @@
 {
-    "recommendations": [ "zxh404.vscode-proto3", "BazelBuild.vscode-bazel", "golang.Go", "rust-lang.rust-analyzer", "meta.sapling-scm", "editorconfig.editorconfig", "dbaeumer.vscode-eslint" ]
+	"recommendations": [
+		"zxh404.vscode-proto3",
+		"BazelBuild.vscode-bazel",
+		"golang.Go",
+		"rust-lang.rust-analyzer",
+		"meta.sapling-scm",
+		"editorconfig.editorconfig",
+		"dbaeumer.vscode-eslint",
+		"vscode-icons-team.vscode-icons"
+	]
 }
-
-
-
-


### PR DESCRIPTION
Add vscode-icons-team.vscode-icons to suggested extensions.
