### PR TITLE
ConnectInstance to have unique instanceAlias name so that prod and staging don't conflict.

### DIFF
--- a/ts/pulumi/zemn.me/voice/voice.ts
+++ b/ts/pulumi/zemn.me/voice/voice.ts
@@ -41,10 +41,11 @@ export class Voice extends Pulumi.ComponentResource {
 				inboundCallsEnabled: true,
 				outboundCallsEnabled: true,
 				identityManagementType: 'CONNECT_MANAGED',
-				instanceAlias: `${name}_connect_instance`.replaceAll(
-					/[^a-z]/g,
-					''
-				),
+				instanceAlias: new RandomPet(
+					`${name}_connect_instance_alias_name`,
+					{},
+					{ parent: this }
+				).id,
 			},
 			{ parent: this }
 		);


### PR DESCRIPTION
ConnectInstance to have unique instanceAlias name so that prod and staging don't conflict.
