### PR TITLE
Introduce scripts to keep go.mod Go version and bazel Go version in sync.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,7 @@
 #   See https://www.npmjs.com/package/@bazel/typescript#installation
 
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@bazel_skylib//rules:native_binary.bzl", "native_test")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:renovate/package_json.bzl", "bin")
@@ -113,6 +114,31 @@ gazelle(
 gazelle(
     name = "gazelle",
     command = "fix",
+)
+
+native_test(
+    name = "go_versions_synced",
+    size = "small",
+    src = "//go/cmd/version_sync",
+    out = "version_sync_test.o",
+    data = [
+        "go.mod",
+        "go_version.bzl",
+    ],
+)
+
+sh_binary(
+    name = "go_versions_synced.fix",
+    srcs = ["fix_go_version_sync.sh"],
+    data = [
+        "//go/cmd/version_sync",
+    ],
+    env = {
+        "VERSION_SYNC": "$(rlocationpath //go/cmd/version_sync)",
+    },
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 bazel_lint(name = "bazel_lint")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,7 +49,9 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.20.7")
+load("//:go_version.bzl", "go_version")
+
+go_register_toolchains(version = go_version)
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 

--- a/fix_go_version_sync.sh
+++ b/fix_go_version_sync.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# run via bazel to fix sync between go.mod Go version
+# and go_version.bzl
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+BIN="$(realpath $(rlocation $VERSION_SYNC))"
+
+cd $BUILD_WORKING_DIRECTORY
+
+$BIN -fix -test=false
+
+

--- a/go/cmd/version_sync/BUILD.bazel
+++ b/go/cmd/version_sync/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//bzl:rules.bzl", "bazel_lint")
+load("//go:rules.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "version_sync",
+    embed = [":version_sync_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "version_sync_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/zemn-me/monorepo/go/cmd/version_sync",
+    visibility = ["//visibility:private"],
+)
+
+bazel_lint(name = "bazel_lint")

--- a/go/cmd/version_sync/main.go
+++ b/go/cmd/version_sync/main.go
@@ -1,0 +1,221 @@
+// cmd version_sync keeps go.mod and go_version.bzl in sync
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+)
+
+var (
+	fix          bool
+	test         bool
+	version_file string
+	module_file  string
+)
+
+func init() {
+	flag.BoolVar(&fix, "fix", false, "Whether to fix the bazel file if it is not in sync.")
+	flag.BoolVar(&test, "test", true, "Whether to return a non-zero status if not in sync.")
+	flag.StringVar(&version_file, "versionFile", "go_version.bzl", "The go_version.bzl file to update. Must have a line with 'go_version = \"xxx\"' in it.")
+	flag.StringVar(&module_file, "moduleFile", "go.mod", "The go.mod file to read from.")
+}
+
+type FileLike interface {
+	io.Reader
+	io.Seeker
+	io.Writer
+	io.Closer
+	Truncate(size int64) error
+}
+
+type File struct {
+	FileLike
+}
+
+func (v File) GetFirstSubmatch(re *regexp.Regexp) (start int, end int, err error) {
+	if _, err = v.Seek(0, io.SeekStart); err != nil {
+		return
+	}
+	versionIndex := re.FindReaderSubmatchIndex(bufio.NewReader(v))
+	if len(versionIndex) < 2*1+2 {
+		err = errors.New("Could not find match")
+		return
+	}
+
+	start, end = versionIndex[2*1], versionIndex[2*1+2-1]
+
+	return
+}
+
+type FileFiddler struct {
+	File
+	SegmentMatcher *regexp.Regexp
+	start          *int
+	end            *int
+	segment        []byte
+}
+
+func (f *FileFiddler) Offsets() (start int, end int, err error) {
+	if f.start == nil || f.end == nil {
+		f.start, f.end = new(int), new(int)
+		if *f.start, *f.end, err = f.GetFirstSubmatch(f.SegmentMatcher); err != nil {
+			f.start, f.end = nil, nil
+			return
+		}
+	}
+
+	return *f.start, *f.end, nil
+}
+
+func (f *FileFiddler) ReadSegment() (segment []byte, err error) {
+	if f.segment != nil {
+		return f.segment, nil
+	}
+
+	var start int
+	var end int
+	if start, end, err = f.Offsets(); err != nil {
+		return
+	}
+
+	f.Seek(int64(start), io.SeekStart)
+	segment = make([]byte, end-start)
+	if _, err = f.Read(segment); err != nil {
+		return
+	}
+
+	return
+}
+
+func (f FileFiddler) OverwriteSegment(n []byte) (err error) {
+	var start int
+	if start, _, err = f.Offsets(); err != nil {
+		return
+	}
+	// buffer the whole file after the end of the match
+	var b bytes.Buffer
+	if _, err = io.Copy(&b, f); err != nil {
+		return
+	}
+	// truncate the file at the beginning of the match
+	if err = f.Truncate(int64(start)); err != nil {
+		return
+	}
+
+	// append the new segment
+	if _, err = f.Seek(int64(start), io.SeekStart); err != nil {
+		return
+	}
+
+	if _, err = io.Copy(f, io.MultiReader(bytes.NewReader(n), &b)); err != nil {
+		return
+	}
+
+	return
+}
+
+var ReVersionFileVersion = regexp.MustCompile(`go_version\s*=\s*"([^"]+)"\n`)
+
+type VersionFile struct {
+	FileFiddler
+}
+
+func (v *VersionFile) LazyInit() {
+	if v.FileFiddler.SegmentMatcher == nil {
+		v.FileFiddler.SegmentMatcher = ReVersionFileVersion
+	}
+}
+
+func (v *VersionFile) Version() (version []byte, err error) {
+	v.LazyInit()
+	return v.ReadSegment()
+}
+
+func (v *VersionFile) SetVersion(b []byte) (err error) {
+	v.LazyInit()
+	return v.OverwriteSegment(b)
+}
+
+var ReModuleFileVersion = regexp.MustCompile(`go ([^\s]+)\n`)
+
+type ModuleFile struct {
+	FileFiddler
+}
+
+func (v *ModuleFile) LazyInit() {
+	if v.FileFiddler.SegmentMatcher == nil {
+		v.FileFiddler.SegmentMatcher = ReModuleFileVersion
+	}
+}
+
+func (v *ModuleFile) Version() (version []byte, err error) {
+	v.LazyInit()
+	return v.ReadSegment()
+}
+
+func (v *ModuleFile) SetVersion(b []byte) (err error) {
+	v.LazyInit()
+	return v.OverwriteSegment(b)
+}
+
+func do() (err error) {
+	var fileMode int = os.O_RDONLY
+	if fix {
+		fileMode = os.O_RDWR
+	}
+	vff, err := os.OpenFile(version_file, fileMode, 0o777)
+	if err != nil {
+		err = fmt.Errorf("Opening version file %+q: %v", version_file, err)
+		return
+	}
+
+	versionFile := VersionFile{FileFiddler: FileFiddler{File: File{FileLike: vff}}}
+	defer versionFile.Close()
+
+	modf, err := os.OpenFile(module_file, fileMode, 0o777)
+	if err != nil {
+		err = fmt.Errorf("Opening module file %+q: %v", module_file, err)
+		return
+	}
+
+	moduleFile := ModuleFile{FileFiddler: FileFiddler{File: File{FileLike: modf}}}
+	defer moduleFile.Close()
+
+	versionFileVersion, err := versionFile.Version()
+	if err != nil {
+		return
+	}
+
+	moduleFileVersion, err := moduleFile.Version()
+	if err != nil {
+		return
+	}
+
+	inSync := bytes.Equal(versionFileVersion, moduleFileVersion)
+
+	if fix && !inSync {
+		err = versionFile.OverwriteSegment(moduleFileVersion)
+		if err != nil {
+			return
+		}
+	}
+
+	if test && !inSync {
+		return fmt.Errorf("%+q and %+q are not in sync. %+q != %+q", version_file, module_file, versionFileVersion, moduleFileVersion)
+	}
+
+	return
+}
+
+func main() {
+	flag.Parse()
+	if err := do(); err != nil {
+		panic(err)
+	}
+}

--- a/go_version.bzl
+++ b/go_version.bzl
@@ -1,0 +1,7 @@
+"""
+Pulled in by WORKSPACE to get the Go version.
+
+We test that it is in sync with go.mod.
+"""
+
+go_version = "1.19"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:best-practices"],
+	"extends": [
+		"config:best-practices"
+	],
 	"automerge": true,
 	"autodiscover": true,
 	"configMigration": true,
@@ -10,9 +12,15 @@
 	"rollbackPrs": true,
 	"rangeStrategy": "pin",
 	"recreateWhen": "always",
-	"ignorePaths": ["**/monorepo/dist/**"],
-	"gitIgnoredAuthors": ["zemnmez+renovate@gmail.com"],
-	"autodiscoverFilter": ["zemn-me/monorepo"],
+	"ignorePaths": [
+		"**/monorepo/dist/**"
+	],
+	"gitIgnoredAuthors": [
+		"zemnmez+renovate@gmail.com"
+	],
+	"autodiscoverFilter": [
+		"zemn-me/monorepo"
+	],
 	"allowedPostUpgradeCommands": [
 		"CARGO_BAZEL_REPIN=1 npx --yes @bazel/bazelisk sync --only=cargo",
 		"npx --yes @bazel/bazelisk run //bzl/fix_api:fix_all //...",
@@ -20,7 +28,11 @@
 	],
 	"packageRules": [
 		{
-			"matchManagers": ["cargo", "bazel"],
+			"matchManagers": [
+				"cargo",
+				"bazel",
+				"gomod"
+			],
 			"postUpgradeTasks": {
 				"commands": [
 					"CARGO_BAZEL_REPIN=1 npx --yes @bazel/bazelisk sync --only=cargo",
@@ -38,11 +50,15 @@
 			}
 		},
 		{
-			"matchPackagePatterns": [ "pulumi_cli_.*" ],
+			"matchPackagePatterns": [
+				"pulumi_cli_.*"
+			],
 			"groupName": "pulumi_cli"
 		},
 		{
-			"matchPackagePatterns": [ "com_googleapis_storage_chromedriver.*" ],
+			"matchPackagePatterns": [
+				"com_googleapis_storage_chromedriver.*"
+			],
 			"groupName": "chromedriver"
 		}
 	]


### PR DESCRIPTION
Introduce scripts to keep go.mod Go version and bazel Go version in sync.
