### PR TITLE
Enable strict typechecking for ts-eslint.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,6 @@
 		"eslint:recommended",
 		"plugin:prettier/recommended",
 		"plugin:react/recommended",
-		"plugin:@typescript-eslint/strict",
 		"plugin:react-hooks/recommended",
 		"plugin:@next/next/recommended"
 	],
@@ -36,6 +35,7 @@
 			"parser": "@typescript-eslint/parser",
 			"extends": [
 				"plugin:@typescript-eslint/eslint-recommended",
+				"plugin:@typescript-eslint/strict-type-checked",
 				"plugin:@typescript-eslint/recommended"
 			],
 			"plugins": [
@@ -50,11 +50,20 @@
 						"allowSingleExtends": true
 					}
 				],
-				"@typescript-eslint/no-unused-vars": "error"
+				"@typescript-eslint/no-unused-vars": "error",
+				"@typescript-eslint/no-non-null-assertion": 0
+			},
+			"parserOptions": {
+				"sourceType": "module",
+				"ecmaVersion": 2020,
+				"project": [
+					"tsconfig.json"
+				]
 			}
 		}
 	],
 	"rules": {
+		"@typescript-eslint/no-non-null-assertion": 0,
 		"react/forbid-elements": [
 			"error",
 			{
@@ -67,7 +76,8 @@
 			}
 		],
 		"no-restricted-imports": [
-			"error", {
+			"error",
+			{
 				"name": "next/link",
 				"message": "<NextLink> is dangerous. Please use the <Link> component instead."
 			}
@@ -157,7 +167,6 @@
 			"error",
 			"as-needed"
 		],
-		"@typescript-eslint/no-non-null-assertion": 0,
 		"@typescript-eslint/no-unnecessary-condition": "error",
 		"no-console": "error"
 	},

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 	},
 	"dependencies": {
 		"@commander-js/extra-typings": "12.0.1",
+		"@jest/globals": "^29.7.0",
 		"@next/eslint-plugin-next": "14.1.4",
 		"@pulumi/command": "4.5.0",
 		"@pulumi/random": "4.16.0",
@@ -110,6 +111,8 @@
 		"@tanstack/react-query": "4.36.1",
 		"@types/bcryptjs": "2.4.6",
 		"@types/d3-array": "3.2.1",
+		"@types/eslint": "^8.56.6",
+		"@types/eslint__js": "^8.42.3",
 		"@types/memoizee": "0.4.11",
 		"@types/pako": "2.0.3",
 		"@types/react-query": "1.2.9",
@@ -125,6 +128,7 @@
 		"eslint-plugin-react-hooks": "4.6.0",
 		"fast-glob": "3.3.2",
 		"glob-promise": "6.0.5",
+		"globals": "link:@types/@jest/globals",
 		"jscpd": "3.5.10",
 		"json-schema-to-typescript": "13.1.2",
 		"memoizee": "0.4.15",
@@ -134,6 +138,7 @@
 		"seedrandom": "3.0.5",
 		"selenium-webdriver": "4.19.0",
 		"serve-handler": "6.1.5",
+		"typescript-eslint": "^7.4.0",
 		"zod": "3.22.4"
 	},
 	"pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@commander-js/extra-typings':
     specifier: 12.0.1
     version: 12.0.1(commander@12.0.0)
+  '@jest/globals':
+    specifier: ^29.7.0
+    version: 29.7.0
   '@next/eslint-plugin-next':
     specifier: 14.1.4
     version: 14.1.4
@@ -32,6 +35,12 @@ dependencies:
   '@types/d3-array':
     specifier: 3.2.1
     version: 3.2.1
+  '@types/eslint':
+    specifier: ^8.56.6
+    version: 8.56.6
+  '@types/eslint__js':
+    specifier: ^8.42.3
+    version: 8.42.3
   '@types/memoizee':
     specifier: 0.4.11
     version: 0.4.11
@@ -77,6 +86,9 @@ dependencies:
   glob-promise:
     specifier: 6.0.5
     version: 6.0.5(glob@8.1.0)
+  globals:
+    specifier: link:@types/@jest/globals
+    version: link:@types/@jest/globals
   jscpd:
     specifier: 3.5.10
     version: 3.5.10
@@ -104,6 +116,9 @@ dependencies:
   serve-handler:
     specifier: 6.1.5
     version: 6.1.5
+  typescript-eslint:
+    specifier: ^7.4.0
+    version: 7.4.0(eslint@8.57.0)(typescript@5.3.3)
   zod:
     specifier: 3.22.4
     version: 3.22.4
@@ -264,7 +279,7 @@ devDependencies:
     version: 9.1.0(eslint@8.57.0)
   eslint-plugin-prettier:
     specifier: 5.1.3
-    version: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
+    version: 5.1.3(@types/eslint@8.56.6)(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
   eslint-plugin-react:
     specifier: 7.34.1
     version: 7.34.1(eslint@8.57.0)
@@ -1737,7 +1752,6 @@ packages:
   /@babel/compat-data@7.22.9:
     resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/compat-data@7.23.5:
     resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
@@ -1764,7 +1778,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/core@7.24.0:
     resolution: {integrity: sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==}
@@ -1796,7 +1809,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
-    dev: true
 
   /@babel/generator@7.23.6:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
@@ -1831,7 +1843,6 @@ packages:
       browserslist: 4.21.9
       lru-cache: 5.1.1
       semver: 6.3.1
-    dev: true
 
   /@babel/helper-compilation-targets@7.23.6:
     resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
@@ -1926,7 +1937,6 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
-    dev: true
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
@@ -2025,7 +2035,6 @@ packages:
       '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helpers@7.24.0:
     resolution: {integrity: sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==}
@@ -2198,7 +2207,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.0):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -2215,7 +2223,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.22.9):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -2224,7 +2231,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.0):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -2302,7 +2308,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.0):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
@@ -2319,7 +2324,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -2337,7 +2341,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.24.0):
     resolution: {integrity: sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==}
@@ -2355,7 +2358,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.0):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -2372,7 +2374,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -2389,7 +2390,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.0):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -2406,7 +2406,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -2423,7 +2422,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -2440,7 +2438,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -2467,7 +2464,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.0):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -2486,7 +2482,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.0):
     resolution: {integrity: sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==}
@@ -3247,7 +3242,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/traverse@7.24.0:
     resolution: {integrity: sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==}
@@ -3971,12 +3965,10 @@ packages:
       get-package-type: 0.1.0
       js-yaml: 3.14.1
       resolve-from: 5.0.0
-    dev: true
 
   /@istanbuljs/schema@0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
-    dev: true
 
   /@jest/console@29.7.0:
     resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
@@ -4053,7 +4045,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-get-type: 29.6.3
-    dev: true
 
   /@jest/expect@29.7.0:
     resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
@@ -4063,7 +4054,6 @@ packages:
       jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@jest/fake-timers@29.7.0:
     resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
@@ -4086,7 +4076,6 @@ packages:
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@jest/reporters@29.7.0:
     resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
@@ -4181,7 +4170,6 @@ packages:
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@jest/types@26.6.2:
     resolution: {integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==}
@@ -7197,6 +7185,18 @@ packages:
     resolution: {integrity: sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==}
     dev: true
 
+  /@types/eslint@8.56.6:
+    resolution: {integrity: sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==}
+    dependencies:
+      '@types/estree': 1.0.1
+      '@types/json-schema': 7.0.12
+
+  /@types/eslint__js@8.42.3:
+    resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
+    dependencies:
+      '@types/eslint': 8.56.6
+    dev: false
+
   /@types/estree-jsx@1.0.0:
     resolution: {integrity: sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==}
     dependencies:
@@ -7205,7 +7205,6 @@ packages:
 
   /@types/estree@1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
-    dev: false
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -7227,7 +7226,6 @@ packages:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
       '@types/node': 20.11.30
-    dev: true
 
   /@types/hast@3.0.3:
     resolution: {integrity: sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==}
@@ -7524,7 +7522,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -7566,7 +7563,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/scope-manager@6.21.0:
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
@@ -7582,7 +7578,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.4.0
       '@typescript-eslint/visitor-keys': 7.4.0
-    dev: true
 
   /@typescript-eslint/type-utils@7.4.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==}
@@ -7602,7 +7597,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/types@6.21.0:
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
@@ -7612,7 +7606,6 @@ packages:
   /@typescript-eslint/types@7.4.0:
     resolution: {integrity: sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==}
     engines: {node: ^18.18.0 || >=20.0.0}
-    dev: true
 
   /@typescript-eslint/typescript-estree@6.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
@@ -7656,7 +7649,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/utils@7.4.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==}
@@ -7675,7 +7667,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@typescript-eslint/visitor-keys@6.21.0:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
@@ -7691,7 +7682,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.4.0
       eslint-visitor-keys: 3.4.3
-    dev: true
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -8030,7 +8020,6 @@ packages:
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-    dev: true
 
   /array.prototype.findlast@1.2.4:
     resolution: {integrity: sha512-BMtLxpV+8BD+6ZPFIWmnUBpQoy+A+ujcg4rhp2iwCRJYA7PEh2MS4NL3lz8EiDlLrJPp2hg9qWihr5pd//jcGw==}
@@ -8259,7 +8248,6 @@ packages:
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-jest-hoist@29.6.3:
     resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
@@ -8329,7 +8317,6 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.22.9)
-    dev: true
 
   /babel-preset-jest@29.6.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
@@ -8549,7 +8536,6 @@ packages:
       electron-to-chromium: 1.4.459
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.9)
-    dev: true
 
   /browserslist@4.23.0:
     resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
@@ -8728,7 +8714,6 @@ packages:
 
   /caniuse-lite@1.0.30001515:
     resolution: {integrity: sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==}
-    dev: true
 
   /caniuse-lite@1.0.30001591:
     resolution: {integrity: sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==}
@@ -9159,7 +9144,6 @@ packages:
 
   /convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-    dev: true
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -9666,7 +9650,6 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
 
   /diff@3.5.0:
     resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
@@ -9686,7 +9669,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
-    dev: true
 
   /doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -9783,7 +9765,6 @@ packages:
 
   /electron-to-chromium@1.4.459:
     resolution: {integrity: sha512-XXRS5NFv8nCrBL74Rm3qhJjA2VCsRFx0OjHKBMPI0otij56aun8UWiKTDABmd5/7GTR021pA4wivs+Ri6XCElg==}
-    dev: true
 
   /electron-to-chromium@1.4.688:
     resolution: {integrity: sha512-3/tHg2ChPF00eukURIB8cSVt3/9oeS1oTUIEt3ivngBInUaEcBhG2VdyEDejhwQdR6SLqaiEAEc0dHS0V52pOw==}
@@ -10354,7 +10335,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5):
+  /eslint-plugin-prettier@5.1.3(@types/eslint@8.56.6)(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5):
     resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -10368,6 +10349,7 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
+      '@types/eslint': 8.56.6
       eslint: 8.57.0
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       prettier: 3.2.5
@@ -10632,7 +10614,6 @@ packages:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
-    dev: true
 
   /exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
@@ -11104,7 +11085,6 @@ packages:
   /get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
-    dev: true
 
   /get-stdin@8.0.0:
     resolution: {integrity: sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==}
@@ -11346,7 +11326,6 @@ packages:
       ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
 
   /globby@13.2.2:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
@@ -12215,7 +12194,6 @@ packages:
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
-    dev: true
 
   /istanbul-lib-instrument@5.2.1:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
@@ -12228,7 +12206,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /istanbul-lib-instrument@6.0.0:
     resolution: {integrity: sha512-x58orMzEVfzPUKqlbLd1hXCnySCxKdDKa6Rjg97CwuLLRI4g3FHTdnExu1OqffVFay6zeMW+T6/DowFLndWnIw==}
@@ -12413,7 +12390,6 @@ packages:
       diff-sequences: 29.6.3
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
-    dev: true
 
   /jest-docblock@29.7.0:
     resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
@@ -12488,7 +12464,6 @@ packages:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /jest-leak-detector@29.7.0:
     resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
@@ -12506,7 +12481,6 @@ packages:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
-    dev: true
 
   /jest-message-util@29.7.0:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
@@ -12545,7 +12519,6 @@ packages:
   /jest-regex-util@29.6.3:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
 
   /jest-resolve-dependencies@29.7.0:
     resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
@@ -12657,7 +12630,6 @@ packages:
       semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
@@ -14617,7 +14589,6 @@ packages:
 
   /node-releases@2.0.13:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
-    dev: true
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
@@ -15422,7 +15393,6 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
 
   /peek-readable@5.0.0:
     resolution: {integrity: sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==}
@@ -16597,7 +16567,6 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: true
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -17736,7 +17705,6 @@ packages:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
-    dev: true
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -17919,7 +17887,6 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.3.3
-    dev: true
 
   /ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.30)(typescript@5.3.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -18140,6 +18107,25 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
+  /typescript-eslint@7.4.0(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-8GYQsb/joknlAZEAs/kqonfrsAc98C5DoellmwHREPqKwSTKSY2YB93IwmvNuX6+WE5QkKc31X9wHo/UcpYXpw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.4.0(@typescript-eslint/parser@7.4.0)(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 7.4.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.4.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /typescript@3.8.3:
     resolution: {integrity: sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==}
     engines: {node: '>=4.2.0'}
@@ -18149,7 +18135,6 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
@@ -18408,7 +18393,6 @@ packages:
       browserslist: 4.21.9
       escalade: 3.1.2
       picocolors: 1.0.0
-    dev: true
 
   /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
@@ -18842,7 +18826,6 @@ packages:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-    dev: true
 
   /write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}

--- a/ts/math/BUILD.bazel
+++ b/ts/math/BUILD.bazel
@@ -8,6 +8,7 @@ ts_project(
     srcs = glob(["*.ts"]),
     deps = [
         "//:node_modules/@types/jest",
+        "//ts",
         "//ts/iter",
     ],
 )

--- a/ts/math/camera.ts
+++ b/ts/math/camera.ts
@@ -7,14 +7,13 @@ export type FocalLength = number;
  * Return a camera matrix given a particular focal length
  * representing a camera about (0, 0, 0)
  */
-export const matrix = (f: FocalLength): Matrix.Matrix<4, 3, number> =>
-	Matrix.as<4, 3>([
-		[1, 0, 0, 0],
-		[0, 1, 0, 0],
-		[0, 0, 1 / f, 0],
-	] as const);
+export const matrix = (f: FocalLength): Matrix.Matrix<4, 3, number> => [
+	[1, 0, 0, 0],
+	[0, 1, 0, 0],
+	[0, 0, 1 / f, 0],
+];
 
 export const transform: (i: Homog.Point3D, f?: FocalLength) => Homog.Point2D = (
 	i,
 	f = 1
-) => Matrix.mul(matrix(f), i);
+) => Matrix.mul<4, 3, 1, 4>(matrix(f), i);

--- a/ts/math/canvas/braille/BUILD.bazel
+++ b/ts/math/canvas/braille/BUILD.bazel
@@ -10,9 +10,10 @@ ts_project(
         "*.tsx",
     ]),
     deps = [
+        "//:node_modules/@jest/globals",
         "//:node_modules/@types/d3-array",
         "//:node_modules/@types/d3-scale",
-        "//:node_modules/@types/jest",
+        "//:node_modules/@types/node",
         "//:node_modules/@types/react",
         "//:node_modules/d3-array",
         "//:node_modules/d3-scale",

--- a/ts/math/canvas/braille/braille_test.ts
+++ b/ts/math/canvas/braille/braille_test.ts
@@ -1,4 +1,5 @@
 import { range } from 'd3-array';
+import { expect, it } from '@jest/globals';
 
 import {
 	plot,

--- a/ts/math/canvas/element.tsx
+++ b/ts/math/canvas/element.tsx
@@ -47,8 +47,8 @@ export const Canvas: React.FC<CanvasProps> = ({ draw }) => {
 		>
 			{[...lines].map(line => {
 				const d = line
-					.map(([pts], i) => {
-						const [x, y] = pts!;
+					.map((pts, i) => {
+						const [[x], [y]] = pts!;
 						const cmd = i > 0 ? 'L' : 'M';
 						return `${cmd}${x},${y}`;
 					})

--- a/ts/math/canvas/element.tsx
+++ b/ts/math/canvas/element.tsx
@@ -18,7 +18,7 @@ export const Canvas: React.FC<CanvasProps> = ({ draw }) => {
 		...(function* () {
 			for (const line of lines) {
 				for (const point of line) {
-					yield point[0]![0]!;
+					yield point[0][0];
 				}
 			}
 		})(),
@@ -28,7 +28,7 @@ export const Canvas: React.FC<CanvasProps> = ({ draw }) => {
 		...(function* () {
 			for (const line of lines) {
 				for (const point of line) {
-					yield point[1]![0]!;
+					yield point[1][0];
 				}
 			}
 		})(),
@@ -48,7 +48,7 @@ export const Canvas: React.FC<CanvasProps> = ({ draw }) => {
 			{[...lines].map(line => {
 				const d = line
 					.map((pts, i) => {
-						const [[x], [y]] = pts!;
+						const [[x], [y]] = pts;
 						const cmd = i > 0 ? 'L' : 'M';
 						return `${cmd}${x},${y}`;
 					})

--- a/ts/math/cartesian.ts
+++ b/ts/math/cartesian.ts
@@ -1,5 +1,5 @@
 import * as Matrix from '#root/ts/math/matrix.js';
-import { map } from '#root/ts/math/vec.js';
+import { map, Vector } from '#root/ts/math/vec.js';
 export type Point<T extends number = number> = Matrix.Matrix<1, T>;
 export type Point2D = Point<2>;
 export type Point3D = Point<3>;
@@ -12,7 +12,7 @@ export type Line3D = Point3D[];
  * rectangle.
  */
 export const rectContaninsPoint =
-	<N extends number>(min: Point<N>) =>
+	<const N extends number>(min: Point<N>) =>
 	(max: Point<N>) =>
 	(point: Point<N>): boolean =>
 		point.every((col, ci) =>
@@ -26,7 +26,7 @@ export const rectContaninsPoint =
  * in the matrix from [[x], [y]].
  */
 export function cartesianCanonicalise<L extends number>(
-	v: Array<number> & { length: L }
+	v: Vector<L>
 ): Point<L> {
-	return map(v, n => [n] as [number]);
+	return map(v, n => [n]);
 }

--- a/ts/math/conv.ts
+++ b/ts/math/conv.ts
@@ -19,8 +19,8 @@ export const Quaternion = {
 		return new quaternion.Quaternion(x, y, z, w);
 	},
 
-	fromPoint3D([pts]: cartesian.Point3D): quaternion.Quaternion {
-		const [x, y, z] = pts!;
+	fromPoint3D(pts: cartesian.Point3D): quaternion.Quaternion {
+		const [[x], [y], [z]] = pts!;
 		return new quaternion.Quaternion(x!, y!, z!, 0);
 	},
 };

--- a/ts/math/math_test.ts
+++ b/ts/math/math_test.ts
@@ -1,4 +1,4 @@
-import { rectContaninsPoint } from '#root/ts/math/cartesian.js';
+import { Point, rectContaninsPoint } from '#root/ts/math/cartesian.js';
 import * as matrix from '#root/ts/math/matrix.js';
 import * as vec from '#root/ts/math/vec.js';
 
@@ -388,11 +388,12 @@ describe('cartesian', () => {
 		const testCases = [
 			[[[0], [0]], [[10], [10]], [[5], [5]], true],
 			[[[0], [0]], [[10], [10]], [[-1], [-1]], false],
-		] as const;
+		] as [min: Point<2>, max: Point<2>, point: Point<2>, result: boolean][];
+
 		test.each(testCases)(
 			'rectContainsPoint(%p)(%p)(%p) → %p',
 			(min, max, point, result) =>
-				expect(rectContaninsPoint(min)(max)(point)).toEqual(result)
+				expect(rectContaninsPoint<2>(min)(max)(point)).toEqual(result)
 		);
 	});
 });

--- a/ts/math/matrix.ts
+++ b/ts/math/matrix.ts
@@ -28,11 +28,11 @@ export const zero = as<0, 0>([] as any);
 export function New<I extends number, J extends number>(
 	i: I,
 	j: J
-): Matrix<I, J, undefined> {
+): Matrix<I, J, unknown> {
 	return vec.map(vec.New(j), () => vec.New(i));
 }
 
-export const add: <I extends number, J extends number>(
+export const add: <const I extends number, const J extends number>(
 	m1: Matrix<I, J>,
 	m2: Matrix<I, J>
 ) => Matrix<I, J> = <I extends number, J extends number>(
@@ -66,30 +66,19 @@ export const col: <I extends number, J extends number, T>(
 	for (let j = 0; j < jsize; j++) yield v[j]![i]!;
 };
 
-export const mul: <
+export function mul<
 	I1 extends number,
 	J1 extends number,
 	I2 extends number,
 	J2 extends number,
->(
-	m1: Matrix<I1, J1>,
-	m2: Matrix<I2, J2>
-) => Multiply<Matrix<I1, J1>, Matrix<I2, J2>> = <
-	I1 extends number,
-	J1 extends number,
-	I2 extends number,
-	J2 extends number,
->(
-	m1: Matrix<I1, J1>,
-	m2: Matrix<I2, J2>
-) => {
+>(m1: Matrix<I1, J1>, m2: Matrix<I2, J2>): Matrix<I2, J1> {
 	const [, /*i1*/ j1] = size(m1);
 	const [i2 /*, j2*/] = size(m2);
 
 	return vec.map(vec.New<J1>(j1), (_, i) =>
 		vec.map(vec.New<I2>(i2), (_, j) => vec.dot(row(m1, i), col(m2, j)))
 	);
-};
+}
 
 export const map: <I extends number, J extends number, T, O>(
 	m: Matrix<I, J, T>,

--- a/ts/math/shape/index.ts
+++ b/ts/math/shape/index.ts
@@ -5,6 +5,7 @@ import { EulerAngle } from '#root/ts/math/euler_angle.js';
 import * as Homog from '#root/ts/math/homog.js';
 import * as Matrix from '#root/ts/math/matrix.js';
 import * as Quaternion from '#root/ts/math/quaternion.js';
+import { map } from '#root/ts/math/vec';
 
 export class Square implements Canvas.Drawable2D {
 	public readonly r: number;
@@ -62,9 +63,9 @@ export class Translate3D<T extends Canvas.Drawable3D>
 	) {}
 
 	public lines3D(): Homog.Line3D[] {
-		return this.target
-			.lines3D()
-			.map(line => line.map(point => Matrix.add(point, this.by)));
+		return map(this.target.lines3D(), line =>
+			map(line, point => Matrix.add<1, 4>(point, this.by))
+		);
 	}
 }
 
@@ -135,7 +136,7 @@ export class QuaternionMultiply<
 	) {}
 	lines3D() {
 		return this.value.lines3D().map(line =>
-			line.map(point => {
+			line.map((point): Homog.Point3D => {
 				const [xi, yi, zi] = Homog.pointToCart(point);
 				const [[x], [y], [z]] = [xi!, yi!, zi!];
 				const q1: Quaternion.Quaternion = new Quaternion.Quaternion(
@@ -148,7 +149,7 @@ export class QuaternionMultiply<
 				const n = q1.multiply(q2);
 
 				const [nx = 0, ny = 0, nz = 0] = [n.x, n.y, n.z];
-				return [[nx], [ny], [nz], [1]] as const;
+				return [[nx], [ny], [nz], [1]];
 			})
 		);
 	}
@@ -175,7 +176,7 @@ export class QuaternionRotate<
 			new EulerAngle(rx!, ry!, rz!)
 		);
 		return this.value.lines3D().map(line =>
-			line.map(point => {
+			line.map((point): Homog.Point3D => {
 				const [xi, yi, zi] = Homog.pointToCart(point);
 				const [[x], [y], [z]] = [xi!, yi!, zi!];
 				const q1: Quaternion.Quaternion = new Quaternion.Quaternion(

--- a/ts/math/vec.ts
+++ b/ts/math/vec.ts
@@ -1,11 +1,6 @@
-interface ReadonlyArrayOfLength<T, I extends number> extends ReadonlyArray<T> {
-	length: I;
-}
+import { Tuple } from '#root/ts/tuple.js';
 
-export interface Vector<I extends number = number, T = number>
-	extends ReadonlyArrayOfLength<T, I> {
-	length: I;
-}
+export type Vector<I extends number = number, T = number> = Tuple<T, I>;
 
 /**
  * Map a Vector, returning a new Vector.
@@ -46,9 +41,9 @@ export const as: <T, L extends number>(
 	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 ) => Vector<L, T> = v => v as any;
 
-export const New: <N extends number>(n: number) => Vector<N, undefined> = n =>
-	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-	[...Array(n)] as any as Vector<any, undefined>;
+export function New<N extends number>(n: number): Vector<N, unknown> {
+	return [...Array(n)] as Vector<N, unknown>;
+}
 
 export const add: <I extends number>(
 	v1: Vector<I>,
@@ -92,8 +87,8 @@ const _zip: <T1, T2, T3>(
 };
 export const zip: {
 	<T1, T2, L extends number>(
-		v1: ReadonlyArrayOfLength<T1, L>,
-		v2: ReadonlyArrayOfLength<T2, L>
+		v1: Vector<L, T1>,
+		v2: Vector<L, T2>
 	): Iterable<[T1, T2]>;
 	<T1, T2, T3>(
 		v1: Iterable<T1>,

--- a/ts/math/vec.ts
+++ b/ts/math/vec.ts
@@ -9,7 +9,7 @@ export const map: <I extends number, T, U>(
 	vec: Vector<I, T>,
 	callbackFn: (value: T, index: number, array: Vector<I, T>) => U
 ) => Vector<I, U> = (vec, c) =>
-	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+	/* eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return */
 	vec.map(c as any) as any;
 
 /**
@@ -38,10 +38,11 @@ export const reverse: <I extends number, T>(v: Vector<I, T>) => Iterable<T> =
 
 export const as: <T, L extends number>(
 	v: readonly T[] & { length: L }
-	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+	/* eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
 ) => Vector<L, T> = v => v as any;
 
 export function New<N extends number>(n: number): Vector<N, unknown> {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	return [...Array(n)] as Vector<N, unknown>;
 }
 
@@ -85,6 +86,8 @@ const _zip: <T1, T2, T3>(
 		yield [left, right];
 	}
 };
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 export const zip: {
 	<T1, T2, L extends number>(
 		v1: Vector<L, T1>,

--- a/ts/tuple.ts
+++ b/ts/tuple.ts
@@ -1,0 +1,8 @@
+export type Tuple<T, N extends number> = N extends N
+	? number extends N
+		? T[]
+		: _TupleOf<T, N, []>
+	: never;
+type _TupleOf<T, N extends number, R extends unknown[]> = R['length'] extends N
+	? R
+	: _TupleOf<T, N, [T, ...R]>;


### PR DESCRIPTION
Enable strict typechecking for ts-eslint.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/4963).
* __->__ #4963
* #4958