### PR TITLE
Go_fmt format tests with aspect_rules_lint.

### DIFF
--- a/go/fmt/BUILD.bazel
+++ b/go/fmt/BUILD.bazel
@@ -3,7 +3,6 @@ load("//bzl:rules.bzl", "bazel_lint")
 exports_files(
     [
         "go.bzl",
-        "test_fmt.sh",
     ],
     visibility = ["//visibility:public"],
 )

--- a/go/fmt/rules.bzl
+++ b/go/fmt/rules.bzl
@@ -1,11 +1,10 @@
-def test_go_fmt(srcs = [], deps = [], **kwargs):
-    native.sh_test(
-        env = {
-            "GOFMT": "$(rootpath @go_sdk//:bin/gofmt)",
-        },
-        deps = deps,
-        srcs = ["//go/fmt:test_fmt.sh"],
-        data = ["@go_sdk//:bin/gofmt"] + srcs,
-        args = ["$(rootpath %s)" % x for x in srcs],
+"Test formatting of Go code."
+
+load("@aspect_rules_lint//format:defs.bzl", "format_test")
+
+def test_go_fmt(srcs = [], **kwargs):
+    format_test(
+        srcs = srcs,
+        go = "@go_sdk//:bin/gofmt",
         **kwargs
     )

--- a/go/fmt/test_fmt.sh
+++ b/go/fmt/test_fmt.sh
@@ -1,8 +1,0 @@
-set -e
-DIFF=$($GOFMT -d -s $@)
-echo "$DIFF"
-test -z "$DIFF"
-
-echo code $?
-set +e
-exit $?

--- a/go/rules.bzl
+++ b/go/rules.bzl
@@ -11,10 +11,11 @@ def go_binary(name = None, srcs = [], embedsrcs = None, importpath = None, deps 
         **kwargs
     )
 
-    _test_go_fmt(
-        name = name + "_fmt",
-        srcs = srcs,
-    )
+    if len(srcs) > 0:
+        _test_go_fmt(
+            name = name + "_fmt",
+            srcs = srcs,
+        )
 
 def go_test(name = None, importpath = None, deps = [], **kwargs):
     _go_test(
@@ -38,7 +39,8 @@ def go_library(name = None, srcs = [], importpath = None, deps = [], **kwargs):
         **kwargs
     )
 
-    _test_go_fmt(
-        name = name + "_fmt",
-        srcs = srcs,
-    )
+    if len(srcs) > 0:
+        _test_go_fmt(
+            name = name + "_fmt",
+            srcs = srcs,
+        )


### PR DESCRIPTION
Go_fmt format tests with aspect_rules_lint.

Needs https://github.com/aspect-build/rules_lint/pull/189 to have landed.
