### PR TITLE
Fix CI for renovate branch automerging.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,17 @@ name: CI
 on:   # yamllint disable-line rule:truthy
   merge_group:
     branches:
-
       # presubmit
       - main
+      - renovate/**
   pull_request:
     branches:
-
       # presubmit
       - main
   push:
     branches:
       - main
+      - renovate/**
 
   # manual triggering
   workflow_dispatch:


### PR DESCRIPTION
Fix CI for renovate branch automerging.

See: https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging

I was getting:

Pending Branch Automerge
These updates await pending status checks before automerging. Click on a checkbox to abort the branch automerge, and create a PR instead.

 chore(deps): pin dependencies (resolve, source-map-loader)
 chore(deps): update dependency mime to v4.0.3
 fix(deps): update dependency devtools-protocol to v0.0.1292262
 fix(deps): update nextjs monorepo to v14.2.3 (@next/eslint-plugin-next, eslint-config-next)
 chore(deps): update dependency @pulumi/awsx to v2.9.0
 chore(deps): update dependency aspect_rules_lint to v0.19.0
 chore(deps): update dependency renovate to v37.323.1
