### PR TITLE
Remove presubmit to removate branches now renovate branch merge is no longer a thing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ on:   # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - renovate/**
 
   # manual triggering
   workflow_dispatch:


### PR DESCRIPTION
Remove presubmit to removate branches now renovate branch merge is no longer a thing.
