### PR TITLE
Lint hotfix: add package.json to runfiles for eslintrc so it can run in module mode.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -140,6 +140,7 @@ js_library(
     srcs = [
         ":eslint.config.js",
         "//:editorconfig",
+        "//:package_json",
         "//:prettierrc",
         "//:tsconfig",
     ],


### PR DESCRIPTION
Lint hotfix: add package.json to runfiles for eslintrc so it can run in module mode.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/5475).
* #5472
* __->__ #5475