### PR TITLE
Hotfix: add @eslint/compat to eslint config

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -145,6 +145,7 @@ js_library(
         "//:tsconfig",
     ],
     deps = [
+        "//:node_modules/@eslint/compat",
         "//:node_modules/@eslint/js",
         "//:node_modules/@next/eslint-plugin-next",
         "//:node_modules/eslint-mdx",

--- a/js/testing/node_version/node_version_test.ts
+++ b/js/testing/node_version/node_version_test.ts
@@ -1,7 +1,7 @@
 test('node version must be at least 18', () => {
 	const match = /^v(\d+)/.exec(process.version);
 	expect(match).not.toBe(null);
-	//eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	 
 	const m = match!;
 	expect(+m[1]!).toBeGreaterThanOrEqual(18);
 });

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"yarn": "1.22.22"
 	},
 	"scripts": {
+		"lint": "eslint --fix",
 		"bazel": "npm run -- bazelisk",
 		"bazelisk": "npx --yes @bazel/bazelisk",
 		"ibazel": "npx --yes @bazel/ibazel",

--- a/project/cultist/element_test.ts
+++ b/project/cultist/element_test.ts
@@ -1,4 +1,5 @@
 import immutable from 'immutable';
+
 import * as cultist from '#root/project/cultist.js';
 
 describe('count', () => {

--- a/project/linear2/features/elements/CodeBlock/index.tsx
+++ b/project/linear2/features/elements/CodeBlock/index.tsx
@@ -55,10 +55,10 @@ declare module 'react-syntax-highlighter' {
 }
 
 export interface CodeProps {
-	children: string;
-	language?: string;
-	lineNumbers?: boolean;
-	name?: string;
+	readonly children: string;
+	readonly language?: string;
+	readonly lineNumbers?: boolean;
+	readonly name?: string;
 }
 
 const Span: (props: highlight.Element<'span'>) => React.ReactElement | null = ({

--- a/project/linear2/features/elements/headingsAndSections/fancy.tsx
+++ b/project/linear2/features/elements/headingsAndSections/fancy.tsx
@@ -15,8 +15,8 @@ export interface HeadingProps<
 type _X<T> = [T] | [T, T] | [T, T, T] | [T, T, T, T] | [T, T, T, T, T];
 
 export interface FancyHeaderProps {
-	headings: _X<HeadingProps>;
-	className?: string;
+	readonly headings: _X<HeadingProps>;
+	readonly className?: string;
 }
 
 export const Header = React.forwardRef<HTMLElement, FancyHeaderProps>(

--- a/project/linear2/features/elements/headingsAndSections/headingsAndSections.tsx
+++ b/project/linear2/features/elements/headingsAndSections/headingsAndSections.tsx
@@ -32,7 +32,7 @@ export type HeaderDepth = 0 | 1 | 2 | 3 | 4 | 5;
 export const SectionDepthContext = React.createContext<HeaderDepth>(0);
 
 export interface HeadingProps extends Omit<PropsOf<'h1'>, 'ref'> {
-	depth: HeaderDepth;
+	readonly depth: HeaderDepth;
 }
 
 export type HeaderComponent =
@@ -135,9 +135,9 @@ export function isDefined<T>(v: T | undefined): v is T {
 }
 
 export interface SectionProps extends Omit<PropsOf<'section'>, 'ref'> {
-	children: [HeadingElement, ...React.ReactElement[]];
-	withSectionMarkers?: boolean;
-	sectionChildWrapperClass?: string;
+	readonly children: [HeadingElement, ...React.ReactElement[]];
+	readonly withSectionMarkers?: boolean;
+	readonly sectionChildWrapperClass?: string;
 }
 
 export const Section = React.forwardRef<HTMLSectionElement, SectionProps>(

--- a/project/linear2/features/elements/headingsAndSections/outlineState.tsx
+++ b/project/linear2/features/elements/headingsAndSections/outlineState.tsx
@@ -23,7 +23,7 @@ export const state = atom<Root>({
 
 const parentCtx = React.createContext<Root | Node | undefined>(undefined);
 
-export const Provide: React.FC<{ element: HeadingElement }> = ({
+export const Provide: React.FC<{ readonly element: HeadingElement }> = ({
 	element,
 	children,
 }) => {

--- a/project/linear2/features/elements/timeline/components.tsx
+++ b/project/linear2/features/elements/timeline/components.tsx
@@ -177,7 +177,7 @@ const romanize = (n: number) => {
 	return parts.join('');
 };
 
-const YearDisplay: React.FC<{ year: Date; n: number }> = ({
+const YearDisplay: React.FC<{ readonly year: Date; readonly n: number }> = ({
 	year: date,
 	n,
 }) => {
@@ -233,8 +233,8 @@ export const Month: (props: MonthProps) => React.ReactElement = ({
 );
 
 export const MonthIndicator: React.FC<{
-	year: number;
-	month: model.time.date.Month;
+	readonly year: number;
+	readonly month: model.time.date.Month;
 }> = ({ month, year }) => {
 	const d = new Date(0);
 	d.setFullYear(year);
@@ -275,7 +275,7 @@ export const Event: (props: EventProps) => React.ReactElement = ({
 		React.useLayoutEffect(() => {
 			if (!concernsCurrent) return;
 
-			ref?.current?.scrollIntoView({
+			ref.current?.scrollIntoView({
 				behavior: 'smooth',
 				block: 'center',
 				inline: 'center',

--- a/project/linear2/features/elements/util.test.ts
+++ b/project/linear2/features/elements/util.test.ts
@@ -52,7 +52,7 @@ describe('iter', () => {
 		});
 
 		it('should ignore undefined classes', () => {
-			expect(iter.classes(undefined, 'a')?.className).toEqual('a');
+			expect(iter.classes(undefined, 'a').className).toEqual('a');
 		});
 	});
 });

--- a/project/zemn.me/app/layout.tsx
+++ b/project/zemn.me/app/layout.tsx
@@ -1,8 +1,8 @@
-/* eslint-disable @next/next/no-page-custom-font */
+ 
 import 'project/zemn.me/app/base.css';
 
-import { Metadata } from 'next/types';
 import { Lora } from 'next/font/google';
+import { Metadata } from 'next/types';
 import { ReactNode } from 'react';
 
 import { Providers } from '#root/project/zemn.me/app/providers.js';

--- a/ts/factorio/upgrade_planner.ts
+++ b/ts/factorio/upgrade_planner.ts
@@ -1,5 +1,6 @@
-import { ItemFilterObject } from "#root/ts/factorio/item_filter_object.js";
 import { z } from "zod";
+
+import { ItemFilterObject } from "#root/ts/factorio/item_filter_object.js";
 
 export const UpgradePlanner = z.strictObject({
 	settings: z.strictObject({

--- a/ts/iter/index.ts
+++ b/ts/iter/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/unified-signatures */
+ 
 export * as dict from '#root/ts/iter/dict.js';
 
 /**

--- a/ts/jest/jest.browser.config.ts
+++ b/ts/jest/jest.browser.config.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef */
+ 
 export default {
 	testEnvironment: 'jsdom',
 	haste: {

--- a/ts/jest/jest.node.config.ts
+++ b/ts/jest/jest.node.config.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef */
+ 
 export default {
 	testEnvironment: 'node',
 	haste: {

--- a/ts/next.js/next.config.ts
+++ b/ts/next.js/next.config.ts
@@ -15,7 +15,7 @@ export const eslint = {
 
 export const output = 'export';
 
-// eslint-disable-next-line
+ 
 export const generateBuildId = async () => { /*REPLACE*/ throw new Error() /*REPLACE*/ };
 
 export const productionBrowserSourceMaps = true;

--- a/ts/pulumi/pleaseintroducemetoyour.dog/app/daily/client.tsx
+++ b/ts/pulumi/pleaseintroducemetoyour.dog/app/daily/client.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @next/next/no-img-element */
+ 
 'use client';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';

--- a/ts/react/PrettyJSON/pretty_json.tsx
+++ b/ts/react/PrettyJSON/pretty_json.tsx
@@ -67,7 +67,7 @@ export const PrettyJSON: React.FC<Props> = function PrettyJSON({
 			{Object.entries(v).map(([k, v]) => (
 				<dl key={k} title={[k, ...path].reverse().join('.')}>
 					<details>
-						{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+						{ }
 						<summary>
 							<dt>
 								<PrettyJSON

--- a/ts/react/element/link/link_test.tsx
+++ b/ts/react/element/link/link_test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-elements */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+ 
 import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';

--- a/ts/react/lang/index.tsx
+++ b/ts/react/lang/index.tsx
@@ -42,7 +42,7 @@ export const tag: (
 export const get = <L extends Language>(v: Text<L>): L => v.language;
 
 // https://github.com/typescript-eslint/typescript-eslint/issues/4062
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint, @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
 export const text = <T extends unknown>(v: Text<string, T>): T => v.text;
 
 export { useLocale } from '#root/ts/react/lang/useLocale.js';


### PR DESCRIPTION
Hotfix: add @eslint/compat to eslint config

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/5476).
* #5472
* __->__ #5476