### PR TITLE
vscode eslint plugin to use flat format.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,6 +43,7 @@
 	"task.allowAutomaticTasks": "on",
 	"rust-analyzer.procMacro.enable": true,
 	"eslint.format.enable": true,
+	"eslint.experimental.useFlatConfig": true,
 	"eslint.onIgnoredFiles": "warn",
 	"editor.codeActionsOnSave": {
 		"source.fixAll": "always"


### PR DESCRIPTION
vscode eslint plugin to use flat format.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/5603).
* #5605
* #5604
* #5598
* #5597
* __->__ #5603