### PR TITLE
Speed up invocations of bazelisk (and thus all commands in sh/bin) by using the non-npx version if available.

### DIFF
--- a/sh/bin/bazelisk
+++ b/sh/bin/bazelisk
@@ -1,2 +1,13 @@
 #!/usr/bin/env bash
-npx @bazel/bazelisk "${@}"
+
+if command -v bazelisk > /dev/null; then
+	bazelisk "${@}"
+else
+	echo "Bazelisk doesn't seem to be in your path --"
+	echo "falling back to trying npx."
+	echo ""
+	echo ""
+	echo "npx is slow, consider installing bazelisk."
+	npx @bazel/bazelisk "${@}"
+fi
+


### PR DESCRIPTION
Speed up invocations of bazelisk (and thus all commands in sh/bin) by using the non-npx version if available.
