### PR TITLE
Renovate: add bazel and bazelisk to set using postUpgradeTasks so that it updates MODULE.bazel.lock.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,10 @@
 				"bazel",
 				"gomod",
 				"pip-compile",
-				"pip_requirements"
+				"pip_requirements",
+				"bazel",
+				"bazel-module",
+				"bazelisk"
 			],
 			"postUpgradeTasks": {
 				"commands": [
@@ -53,7 +56,7 @@
 					"go.mod",
 					"MODULE.bazel",
 					"MODULE.bazel.lock",
-					"gazelle_python.yaml",
+					"gazelle_python.yaml"
 				],
 				"recreateWhen": "always"
 			}


### PR DESCRIPTION
Renovate: add bazel and bazelisk to set using postUpgradeTasks so that it updates MODULE.bazel.lock.
