### PR TITLE
Remove "opened" and "syncronize" from sapling workflow; they don't

### DIFF
--- a/.github/workflows/sapling.yml
+++ b/.github/workflows/sapling.yml
@@ -3,9 +3,7 @@ on:
   pull_request:
     types:
       - edited
-      - opened
       - synchronize
-      - reopened
 
 jobs:
   merge_in_order:


### PR DESCRIPTION
include a PR body.
