### PR TITLE
When gazelle generates a build file for the first time, ensure it has lint rules (so we don't need

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -252,6 +252,7 @@ py_venv(
         "//bzl/versioning",
         "//ini/git/merge_drivers/bazel_lockfile",
         "//project/cultist/gen/testing",
+        "//py/hello_world:hello_world_bin",
         "//py/ibazel:ibazel_bin",
         "//py/sectxt:sectxt_bin",
     ],

--- a/go/gazelle/bazel/bazel.go
+++ b/go/gazelle/bazel/bazel.go
@@ -124,6 +124,10 @@ func (Language) GenerateRules(args language.GenerateArgs) language.GenerateResul
 		files = append(files, v)
 	}
 
+	if args.File == nil {
+		files = append(files, "BUILD.bazel") // new file being generated!
+	}
+
 	if len(files) < 1 {
 		return language.GenerateResult{}
 	}

--- a/go/gazelle/venv/package.go
+++ b/go/gazelle/venv/package.go
@@ -120,8 +120,18 @@ func (this Language) GenerateRules(args language.GenerateArgs) (result language.
 			continue
 		}
 
+		var base *string
+
+		if args.File != nil {
+			base = &args.File.Pkg
+		}
+
+		if base == nil {
+			base = &args.Rel
+		}
+
 		args.Config.Exts[this.Name()].(*Context).VenvDeps = append(args.Config.Exts[this.Name()].(*Context).VenvDeps,
-			"//"+args.File.Pkg+":"+r.Name())
+			"//"+*base+":"+r.Name())
 	}
 	return
 }

--- a/py/hello_world/BUILD.bazel
+++ b/py/hello_world/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//bzl:rules.bzl", "bazel_lint")
+load("//py:rules.bzl", "py_binary")
+
+py_binary(
+    name = "hello_world_bin",
+    srcs = ["__main__.py"],
+    main = "__main__.py",
+    visibility = ["//:__subpackages__"],
+)
+
+bazel_lint(
+    name = "bazel_lint",
+    srcs = ["BUILD.bazel"],
+)

--- a/py/hello_world/__main__.py
+++ b/py/hello_world/__main__.py
@@ -1,0 +1,3 @@
+
+
+print("Hello, world!")

--- a/py/sectxt/__main__.py
+++ b/py/sectxt/__main__.py
@@ -9,3 +9,4 @@ if len(s.errors):
 		"{}:{} [{}]: {}".format(argv[1], error['line'], error['code'], error['message'])
 		for error in s.errors)))
 
+


### PR DESCRIPTION
to run gazelle twice).
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zemn-me/monorepo/pull/6404).
* __->__ #6404
* #6402