### PR TITLE
just make renovate use bazelisk again.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
 		"zemn-me/monorepo"
 	],
 	"allowedPostUpgradeCommands": [
-		"XDG_CACHE_HOME=/home/ubuntu CARGO_BAZEL_REPIN=true npx --yes @bazel/bazelisk run --tool_tag=postupgrade //ci:postupgrade"
+		"XDG_CACHE_HOME=/home/ubuntu CARGO_BAZEL_REPIN=true bazelisk run --tool_tag=postupgrade //ci:postupgrade"
 	],
 	"packageRules": [
 		{
@@ -50,7 +50,7 @@
 			],
 			"postUpgradeTasks": {
 				"commands": [
-					"XDG_CACHE_HOME=/home/ubuntu CARGO_BAZEL_REPIN=true npx --yes @bazel/bazelisk run --tool_tag=postupgrade //ci:postupgrade"
+					"XDG_CACHE_HOME=/home/ubuntu CARGO_BAZEL_REPIN=true bazelisk run --tool_tag=postupgrade //ci:postupgrade"
 				],
 				"executionMode": "branch",
 				"fileFilters": [


### PR DESCRIPTION

thus far i have not been able to fix renovate.

that said, the renovate base image claims to have bazelisk: https://github.com/containerbase/base/blob/483ab25f05e6bb6081503a246fab88cf890fc862/test/Dockerfile.distro#L48

so even though this won't improve the broken state, this will at least help me get toward working out why
ghe isn't seeing bazelisk.
