### PR TITLE
Provide glibc to the hello_world go image.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,6 +23,18 @@ oci.pull(
         "linux/ppc64le",
     ],
 )
+oci.pull(
+    name = "distroless_debian12",
+    digest = "sha256:fe3521b45c4985199f810f7db472de6cd6164799ed13605db1d699011e860c23",
+    image = "gcr.io/distroless/base-debian12",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+        "linux/arm/v7",
+        "linux/s390x",
+        "linux/ppc64le",
+    ],
+)
 
 # For each oci.pull call, repeat the "name" here to expose them as dependencies.
 use_repo(
@@ -33,6 +45,12 @@ use_repo(
     "distroless_base_linux_arm_v7",
     "distroless_base_linux_ppc64le",
     "distroless_base_linux_s390x",
+    "distroless_debian12",
+    "distroless_debian12_linux_amd64",
+    "distroless_debian12_linux_arm64_v8",
+    "distroless_debian12_linux_arm_v7",
+    "distroless_debian12_linux_ppc64le",
+    "distroless_debian12_linux_s390x",
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.10.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1198,7 +1198,7 @@
     "@@rules_oci~//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "tSFCgHR/xGxzbUpoIM6IJBi3LkPglkNx8iXpSPFoGaM=",
-        "usagesDigest": "6nBkfFa2UUUKVcg6LG4KCmdjaCDw4j5WPIVL1UXueN4=",
+        "usagesDigest": "lR/3FV30IxKIqZE/ux0+HKBKwY68MvfKhn+p+8NFL5Q=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1285,6 +1285,91 @@
                 "@@platforms//cpu:ppc": "@distroless_base_linux_ppc64le"
               },
               "bzlmod_repository": "distroless_base",
+              "reproducible": true
+            }
+          },
+          "distroless_debian12_linux_amd64": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/base-debian12",
+              "identifier": "sha256:fe3521b45c4985199f810f7db472de6cd6164799ed13605db1d699011e860c23",
+              "platform": "linux/amd64",
+              "target_name": "distroless_debian12_linux_amd64",
+              "bazel_tags": []
+            }
+          },
+          "distroless_debian12_linux_arm64_v8": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/base-debian12",
+              "identifier": "sha256:fe3521b45c4985199f810f7db472de6cd6164799ed13605db1d699011e860c23",
+              "platform": "linux/arm64/v8",
+              "target_name": "distroless_debian12_linux_arm64_v8",
+              "bazel_tags": []
+            }
+          },
+          "distroless_debian12_linux_arm_v7": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/base-debian12",
+              "identifier": "sha256:fe3521b45c4985199f810f7db472de6cd6164799ed13605db1d699011e860c23",
+              "platform": "linux/arm/v7",
+              "target_name": "distroless_debian12_linux_arm_v7",
+              "bazel_tags": []
+            }
+          },
+          "distroless_debian12_linux_s390x": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/base-debian12",
+              "identifier": "sha256:fe3521b45c4985199f810f7db472de6cd6164799ed13605db1d699011e860c23",
+              "platform": "linux/s390x",
+              "target_name": "distroless_debian12_linux_s390x",
+              "bazel_tags": []
+            }
+          },
+          "distroless_debian12_linux_ppc64le": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/base-debian12",
+              "identifier": "sha256:fe3521b45c4985199f810f7db472de6cd6164799ed13605db1d699011e860c23",
+              "platform": "linux/ppc64le",
+              "target_name": "distroless_debian12_linux_ppc64le",
+              "bazel_tags": []
+            }
+          },
+          "distroless_debian12": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_alias",
+            "attributes": {
+              "target_name": "distroless_debian12",
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/base-debian12",
+              "identifier": "sha256:fe3521b45c4985199f810f7db472de6cd6164799ed13605db1d699011e860c23",
+              "platforms": {
+                "@@platforms//cpu:x86_64": "@distroless_debian12_linux_amd64",
+                "@@platforms//cpu:arm64": "@distroless_debian12_linux_arm64_v8",
+                "@@platforms//cpu:armv7": "@distroless_debian12_linux_arm_v7",
+                "@@platforms//cpu:s390x": "@distroless_debian12_linux_s390x",
+                "@@platforms//cpu:ppc": "@distroless_debian12_linux_ppc64le"
+              },
+              "bzlmod_repository": "distroless_debian12",
               "reproducible": true
             }
           },
@@ -1692,7 +1777,13 @@
             "distroless_base_linux_arm64_v8",
             "distroless_base_linux_arm_v7",
             "distroless_base_linux_s390x",
-            "distroless_base_linux_ppc64le"
+            "distroless_base_linux_ppc64le",
+            "distroless_debian12",
+            "distroless_debian12_linux_amd64",
+            "distroless_debian12_linux_arm64_v8",
+            "distroless_debian12_linux_arm_v7",
+            "distroless_debian12_linux_s390x",
+            "distroless_debian12_linux_ppc64le"
           ],
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",

--- a/ts/pulumi/zemn.me/hello_world/BUILD.bazel
+++ b/ts/pulumi/zemn.me/hello_world/BUILD.bazel
@@ -31,7 +31,7 @@ pkg_tar(
 
 oci_image(
     name = "image",
-    base = "@distroless_base",
+    base = "@distroless_debian12",
     entrypoint = ["/hello_world"],
     tars = [":tar"],
 )


### PR DESCRIPTION

/hello_world: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /hello_world)
/hello_world: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /hello_world)
INIT_REPORT Init Duration: 123.14 ms	Phase: init	Status: error	Error Type: Runtime.ExitError
/hello_world: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /hello_world)
/hello_world: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /hello_world)
INIT_REPORT Init Duration: 0.85 ms	Phase: invoke	Status: error	Error Type: Runtime.ExitError
START RequestId: 1e6c7b6d-1736-4f27-967c-78fb3e0f6896 Version: $LATEST
RequestId: 1e6c7b6d-1736-4f27-967c-78fb3e0f6896 Error: Runtime exited with error: exit status 1
Runtime.ExitError
END RequestId: 1e6c7b6d-1736-4f27-967c-78fb3e0f6896
REPORT RequestId: 1e6c7b6d-1736-4f27-967c-78fb3e0f6896	Duration: 3.24 ms	Billed Duration: 4 ms	Memory Size: 512 MB	Max Memory Used: 3 MB	
