### PR TITLE
Oci pulumi: upload image when its digest changes.

### DIFF
--- a/ts/pulumi/lib/oci/image.ts
+++ b/ts/pulumi/lib/oci/image.ts
@@ -20,6 +20,10 @@ export interface OciImageArgs {
 	 * Executable used to push the image — expected to be output of oci_push rule.
 	 */
 	push: Input<string>
+	/**
+	 * Digest uniquely identifying the image.
+	 */
+	digest: Input<string>
 }
 
 /**
@@ -112,7 +116,8 @@ export class OCIImage extends ComponentResource {
 				args.push,
 				"--repository",
 				args.repository
-			]
+			],
+			triggers: [ args.digest ]
 		}, { parent: this });
 
 		this.uri = upload.stdout;

--- a/ts/pulumi/lib/oci/oci_image.tmpl.ts
+++ b/ts/pulumi/lib/oci/oci_image.tmpl.ts
@@ -1,4 +1,6 @@
-import { ComponentResource, ComponentResourceOptions, Input, Output } from "@pulumi/pulumi";
+import { readFile } from "node:fs/promises";
+
+import { ComponentResource, ComponentResourceOptions, Input, Output, output } from "@pulumi/pulumi";
 
 import { OCIImage } from "#root/ts/pulumi/lib/oci/image.js";
 
@@ -10,6 +12,7 @@ export interface Args {
 
 export class __ClassName extends ComponentResource {
 	url: Output<string>
+	static digestPath: string = "__DIGEST"
 	constructor(
 		name: string,
 		args: Args,
@@ -21,6 +24,7 @@ export class __ClassName extends ComponentResource {
 			`${name}_oci_image`,
 			{
 				push: "__PUSH_BIN",
+				digest: output(readFile(__ClassName.digestPath).then(f => f.toString())),
 				...args
 			},
 			{ parent: this }

--- a/ts/pulumi/lib/oci/rules.bzl
+++ b/ts/pulumi/lib/oci/rules.bzl
@@ -42,11 +42,13 @@ def pulumi_image(
         out = out,
         data = [
             ":" + name + "_push_bin",
+            src + ".digest",
         ],
         substitutions = {
             "__ClassName": component_name,
             "__TYPE": native.package_name().replace("/", ":"),
             "__PUSH_BIN": "$(rootpath :" + name + "_push_bin" + ")",
+            "__DIGEST": "$(rootpath " + src + ".digest)",
         },
     )
 
@@ -55,6 +57,7 @@ def pulumi_image(
         srcs = [name + "_tsfiles"],
         data = [
             ":" + name + "_push_bin",
+            src + ".digest",
         ],
         deps = [
             "//:node_modules/@pulumi/pulumi",


### PR DESCRIPTION

We were getting errors at deploy time when the image did not change:


```

    command:local:Command (monorepo_zemn.me_fargate_img_oci_image_push):
      error: 2025/01/01 23:57:07 existing manifest: sha256:a44bf22c85a4ebb85f1c4a2883976090d2a3a3a0f6ce1d26c089533f7c6eba93

```
