### PR TITLE
Keep rust toolchain in sync with rust version.

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "b95dca1b68188a08ca6af9d96a6576150f598824bdb528c1190460c2940a0b48"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "9ab52925392148efd3f7562f2136a81ffb778076bcc85727c6e020d6dd57cf15"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1064,7 +1064,7 @@ dependencies = [
 name = "monorepo"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.26",
+ "clap 4.5.25",
  "hex",
  "rxp",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "b95dca1b68188a08ca6af9d96a6576150f598824bdb528c1190460c2940a0b48"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "9ab52925392148efd3f7562f2136a81ffb778076bcc85727c6e020d6dd57cf15"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1209,7 +1209,7 @@ dependencies = [
 name = "monorepo"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.26",
+ "clap 4.5.25",
  "hex",
  "rxp",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "=4.5.26", features = ["derive"] }
+clap = { version = "=4.5.25", features = ["derive"] }
 swc_common = "=0.36.0"
 sha2 = "=0.10.8"
 hex = "=0.4.3"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,16 +57,19 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_register_toolchains(edition = "2021")
-
-# this rule is really weird. see docs https://github.com/bazelbuild/rules_rust/blob/main/crate_universe/private/crates_repository.bzl#L137
-load("@rules_rust//crate_universe:defs.bzl", "crates_repository")
-
 # renovate:
 # 	datasource=github-releases
 # 	versioning=rust
 # 	depName=rust-lang/rust
-RUST_VERSION = "1.84.0"
+RUST_VERSION = "1.83.0"
+
+rust_register_toolchains(
+    edition = "2021",
+    versions = [RUST_VERSION],
+)
+
+# this rule is really weird. see docs https://github.com/bazelbuild/rules_rust/blob/main/crate_universe/private/crates_repository.bzl#L137
+load("@rules_rust//crate_universe:defs.bzl", "crates_repository")
 
 crates_repository(
     name = "cargo",

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "de5b6767335a07d638630469ecc9c86c8ac61dccd61535cbdffbe88300ddc025",
+  "checksum": "b712c8eb82c960f6e1682b986f84f986e5b32fcea1768517d33e32b0a25a2af4",
   "crates": {
     "Inflector 0.11.4": {
       "name": "Inflector",
@@ -2315,14 +2315,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "clap 4.5.26": {
+    "clap 4.5.25": {
       "name": "clap",
-      "version": "4.5.26",
+      "version": "4.5.25",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap/4.5.26/download",
-          "sha256": "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+          "url": "https://static.crates.io/crates/clap/4.5.25/download",
+          "sha256": "b95dca1b68188a08ca6af9d96a6576150f598824bdb528c1190460c2940a0b48"
         }
       },
       "targets": [
@@ -2372,7 +2372,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.5.26",
+              "id": "clap_builder 4.5.25",
               "target": "clap_builder"
             }
           ],
@@ -2388,7 +2388,7 @@
           ],
           "selects": {}
         },
-        "version": "4.5.26"
+        "version": "4.5.25"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2397,14 +2397,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_builder 4.5.26": {
+    "clap_builder 4.5.25": {
       "name": "clap_builder",
-      "version": "4.5.26",
+      "version": "4.5.25",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_builder/4.5.26/download",
-          "sha256": "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+          "url": "https://static.crates.io/crates/clap_builder/4.5.25/download",
+          "sha256": "9ab52925392148efd3f7562f2136a81ffb778076bcc85727c6e020d6dd57cf15"
         }
       },
       "targets": [
@@ -2459,7 +2459,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.5.26"
+        "version": "4.5.25"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -7604,7 +7604,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.5.26",
+              "id": "clap 4.5.25",
               "target": "clap"
             },
             {
@@ -20655,7 +20655,7 @@
     }
   },
   "binary_crates": [
-    "clap 4.5.26",
+    "clap 4.5.25",
     "phf_generator 0.11.2",
     "pulldown-cmark 0.9.6",
     "rxp 0.2.0"
@@ -21111,7 +21111,7 @@
     ]
   },
   "direct_deps": [
-    "clap 4.5.26",
+    "clap 4.5.25",
     "hex 0.4.3",
     "rxp 0.2.0",
     "serde_json 1.0.135",

--- a/rs/ts/cmd/extract_imports/main.rs
+++ b/rs/ts/cmd/extract_imports/main.rs
@@ -35,6 +35,9 @@ impl convert::From<ExtractImportsError> for ExtractImportsCmdError {
     }
 }
 
+// below is due to passing the output of `println!` to Result::Ok -- but this
+// is intentional on my part.
+#[allow(clippy::unit_arg)]
 fn act() -> Result<(), ExtractImportsCmdError> {
     Result::Ok(println!(
         "{}",


### PR DESCRIPTION

This commit will revert the following commits:

Back out "fix(deps): update rust crate clap to v4.5.26"

Original commit changeset: ee4c73e81386



Back out "chore(deps): update dependency rust-lang/rust to v1.84.0"

Original commit changeset: d1e8b178d18e
