### PR TITLE
Back out "Back out "Pulumi Dynamic provider for Twilio phone numbers.""

### DIFF
--- a/ts/pulumi/index.ts
+++ b/ts/pulumi/index.ts
@@ -136,7 +136,9 @@ export class Component extends Pulumi.ComponentResource {
 
 		new TwilioPhoneNumber(`${name}_twiliophone`, {
 			countryCode: 'US',
-			options: {}
+			options: {
+				voiceUrl: 'https://twimlets.com/message?Message%5B0%5D=If+you+are+hearing+this%2C+then+it+must+be+working%21'
+			}
 		}, { parent: this });
 
 		super.registerOutputs({

--- a/ts/pulumi/lib/twilio/phone_number.ts
+++ b/ts/pulumi/lib/twilio/phone_number.ts
@@ -45,7 +45,7 @@ class TwilioPhoneNumberProvider implements dynamic.ResourceProvider<TwilioPhoneN
 		const num = await client.incomingPhoneNumbers(id).fetch();
 		return {
 			id: num.sid,
-			outs: num
+			outs: num.toJSON()
 		};
     }
 


### PR DESCRIPTION

Original commit changeset: 4fda90d7a9b7



Back out "Pulumi Dynamic provider for Twilio phone numbers."

Original commit changeset: 5f4c2cf255cd

Errors as follows:

```

    Duration: 34s

        at makeError (/home/runner/.cache/bazel/_bazel_runner/ee3b3f377828520170ae98f5c40d2da2/execroot/_main/bazel-out/k8-fastbuild/bin/ci/submit_/submit.runfiles/_main/node_modules/.aspect_rules_js/execa@5.1.1/node_modules/execa/lib/error.js:60:11)
        at handlePromise (/home/runner/.cache/bazel/_bazel_runner/ee3b3f377828520170ae98f5c40d2da2/execroot/_main/bazel-out/k8-fastbuild/bin/ci/submit_/submit.runfiles/_main/node_modules/.aspect_rules_js/execa@5.1.1/node_modules/execa/index.js:118:26)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
      shortMessage: 'Command failed with exit code 255: pulumi up --yes --skip-preview --logtostderr --client=127.0.0.1:36669 --exec-kind auto.inline --stack prod --non-interactive',
      command: 'pulumi up --yes --skip-preview --logtostderr --client=127.0.0.1:36669 --exec-kind auto.inline --stack prod --non-interactive',
      escapedCommand: 'pulumi up --yes --skip-preview --logtostderr "--client=127.0.0.1:36669" --exec-kind auto.inline --stack prod --non-interactive',
      exitCode: 255,
      signal: undefined,
      signalDescription: undefined,
      stdout: 'Updating (prod)\n' +
        '\n' +
        'View Live: https://app.pulumi.com/Zemnmez/monorepo-2/prod/updates/9384\n' +
        '\n' +
        '\n' +
        '@ Updating.......\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_anna_shadwell_im_website_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_lucy_shadwell_im_website_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_lulu_lulu-computer_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        '@ Updating........\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_baby_baby-computer_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_zemn-me_zemn_me_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_pleaseintroducemetoyour-dog_pleaseintroducemetoyour_dog_website_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_thomas_shadwell_im_website_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_luke_shadwell_im_website_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_kate_shadwell_im_website_response_headers updating (0s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_lulu_lulu-computer_response_headers updated (5s) [diff: ~customHeadersConfig]\n' +
        '@ Updating....\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_lucy_shadwell_im_website_response_headers updated (6s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_zemn-me_zemn_me_response_headers updated (1s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_baby_baby-computer_response_headers updated (1s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_thomas_shadwell_im_website_response_headers updated (1s) [diff: ~customHeadersConfig]\n' +
        '@ Updating....\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_pleaseintroducemetoyour-dog_pleaseintroducemetoyour_dog_website_response_headers updated (1s) [diff: ~customHeadersConfig]\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_anna_shadwell_im_website_response_headers updated (7s) [diff: ~customHeadersConfig]\n' +
        '@ Updating......\n' +
        ' +  pulumi-nodejs:dynamic:Resource monorepo_twiliophone creating (0s) \n' +
        '@ Updating.....\n' +
        ' +  pulumi-nodejs:dynamic:Resource monorepo_twiliophone creating (2s) error: Unexpected struct type.\n' +
        ' +  pulumi-nodejs:dynamic:Resource monorepo_twiliophone **creating failed** error: Unexpected struct type.\n' +
        '@ Updating........\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_luke_shadwell_im_website_response_headers updated (11s) [diff: ~customHeadersConfig]\n' +
        '@ Updating...............\n' +
        ' ~  aws:cloudfront:ResponseHeadersPolicy monorepo_shadwell-im_kate_shadwell_im_website_response_headers updated (24s) [diff: ~customHeadersConfig]\n' +
        '    pulumi:pulumi:Stack monorepo-2-prod running error: update failed\n' +
        '    pulumi:pulumi:Stack monorepo-2-prod **failed** 1 error\n' +
        'Diagnostics:\n' +
        '  pulumi-nodejs:dynamic:Resource (monorepo_twiliophone):\n' +
        '    error: Unexpected struct type.\n' +
        '\n' +
        '  pulumi:pulumi:Stack (monorepo-2-prod):\n' +
        '    error: update failed\n' +
        '\n' +
        'Resources:\n' +
        '    ~ 9 updated\n' +
        '    76 unchanged\n' +
        '\n' +
        'Duration: 34s\n',
      stderr: "W0221 14:27:07.175720   14363 pulumi.go:531] A new version of Pulumi is available. To upgrade from version '3.149.0' to '3.150.0', visit https://pulumi.com/docs/install/ for manual instructions and release notes.\n" +
        'I0221 14:27:10.770260   14363 plugin.go:282] Hiding logs from "aws (resource)":"/home/runner/.pulumi/plugins/resource-aws-v6.68.0/pulumi-resource-aws"\n' +
        'I0221 14:27:24.548307   14363 plugin.go:282] Hiding logs from "command (resource)":"/home/runner/.pulumi/plugins/resource-command-v4.5.0/pulumi-resource-command"',
      failed: true,
      timedOut: false,
      isCanceled: false,
      killed: false
    }
  }
}
```
