### PR TITLE
Back out "Pin pulumi command to 1.0.2 (how the hell was it 4.xx??)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"@jest/globals": "29.7.0",
 		"@mdx-js/mdx": "3.1.0",
 		"@next/eslint-plugin-next": "15.2.2",
-		"@pulumi/command": "1.0.2",
+		"@pulumi/command": "4.5.0",
 		"@pulumi/gcp": "8.21.0",
 		"@pulumi/random": "4.18.0",
 		"@react-spring/rafz": "9.7.5",


### PR DESCRIPTION

Justification: https://github.com/pulumi/pulumi-command/issues/709

Original commit changeset: 64be311c7a60
