### PR TITLE
Make duplicate digits in codes fungible (due to bad DTMF parsing).

### DIFF
--- a/ts/pulumi/zemn.me/api/server/BUILD.bazel
+++ b/ts/pulumi/zemn.me/api/server/BUILD.bazel
@@ -22,6 +22,7 @@ go_oapi_codegen(
 go_library(
     name = "server",
     srcs = [
+        "TestRemoveDuplicateDigits.go",
         "api.gen.go",
         "callbox_settings.go",
         "date.go",

--- a/ts/pulumi/zemn.me/api/server/TestRemoveDuplicateDigits.go
+++ b/ts/pulumi/zemn.me/api/server/TestRemoveDuplicateDigits.go
@@ -1,0 +1,26 @@
+package apiserver
+
+import "testing"
+
+func TestRemoveDuplicateDigits(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"112233445566", "123456"},
+		{"1111111", "1"},
+		{"121212", "121212"},
+		{"", ""},
+		{"a111b222c", "a1b2c"},
+		{"a1b2c3", "a1b2c3"},
+		{"1234444555", "12345"},
+		{"00aa00", "0aa0"},
+	}
+
+	for _, tt := range tests {
+		result := removeDuplicateDigits(tt.input)
+		if result != tt.expected {
+			t.Errorf("removeDuplicateDigits(%q) = %q; expected %q", tt.input, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION


To get optimally low keyspace reduction I should only replace up to a doubling, but its ok for now.
