### PR TITLE
Back out "fix(deps): update dependency twilio to v5.5.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 		"source-map-loader": "5.0.0",
 		"to-vfile": "8.0.0",
 		"trusted-types": "2.0.0",
-		"twilio": "5.5.1",
+		"twilio": "5.4.5",
 		"typescript-eslint": "8.27.0",
 		"unified": "11.0.5",
 		"vfile": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,8 +195,8 @@ dependencies:
     specifier: 2.0.0
     version: 2.0.0
   twilio:
-    specifier: 5.5.1
-    version: 5.5.1
+    specifier: 5.4.5
+    version: 5.4.5
   typescript-eslint:
     specifier: 8.27.0
     version: 8.27.0(eslint@9.22.0)(typescript@5.5.4)
@@ -19385,8 +19385,8 @@ packages:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
     dev: true
 
-  /twilio@5.5.1:
-    resolution: {integrity: sha512-b1gLd2eMsCSCHRerp3GQUedVlz0nCTt5FbyPxDPmMvk5cm6eIPk4ZTp5JNpgucARZgpCB2uUACJbdcidEHAUBA==}
+  /twilio@5.4.5:
+    resolution: {integrity: sha512-PIteif0CBOrA42SWZiT8IwUuqTNakAFgvXYWsrjEPGaDSczu/GvBs3vUock4S+UguXj7cV4qBswWgXs5ySjGNg==}
     engines: {node: '>=14.0'}
     dependencies:
       axios: 1.8.3

--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,7 @@
 			"matchPackageNames": [
 				"twilio"
 			],
-			"allowedVersions": "!/5.5.0/"
+			"enabled": false
 		},
 		{
 			"matchManagers": [


### PR DESCRIPTION

Also prevents upgrading the twilio nodejs sdk. For reasons that are currently beyond me, it breaks on upgrade expecting to load the older version:

        pulumi:pulumi:Stack (monorepo-2-prod):
          Error: Cannot find module '.aspect_rules_js/twilio@5.4.5/node_modules/twilio/lib/index.js'
          Require stack:
          -
          -

Original commit changeset: cf67c14fe6be
