### PR TITLE
Have openapi-codegen generate the "strict server".

### DIFF
--- a/ts/pulumi/zemn.me/api/server/BUILD.bazel
+++ b/ts/pulumi/zemn.me/api/server/BUILD.bazel
@@ -14,6 +14,7 @@ go_oapi_codegen(
     generate = [
         "chi-server",
         "models",
+        "strict-server",
     ],
     package = "apiserver",
     source = "//ts/pulumi/zemn.me/api:spec.yaml",
@@ -48,6 +49,7 @@ go_library(
         "@com_github_google_uuid//:uuid",
         "@com_github_nyaruka_phonenumbers//:phonenumbers",
         "@com_github_oapi_codegen_runtime//:runtime",
+        "@com_github_oapi_codegen_runtime//strictmiddleware/nethttp",
         "@com_github_oapi_codegen_runtime//types",
         "@com_github_twilio_twilio_go//twiml",
     ],

--- a/ts/pulumi/zemn.me/api/server/imports.go
+++ b/ts/pulumi/zemn.me/api/server/imports.go
@@ -4,4 +4,5 @@ import (
 	// allows go mod and gazelle to generate imports correctly.
 	_ "github.com/oapi-codegen/runtime"
 	_ "github.com/oapi-codegen/runtime/types"
+	_ "github.com/oapi-codegen/runtime/strictmiddleware/nethttp"
 )

--- a/ts/pulumi/zemn.me/api/server/phone.go
+++ b/ts/pulumi/zemn.me/api/server/phone.go
@@ -293,8 +293,22 @@ func (s *Server) GetPhoneHandleEntry(w http.ResponseWriter, rq *http.Request, pa
 	}
 }
 
-func (Server) GetPhoneNumber(w http.ResponseWriter, r *http.Request) {
+func (s *Server) getPhoneNumber(w http.ResponseWriter, r *http.Request) (err error) {
+	if err := useOIDCAuth(w, r); err != nil {
+		return err
+	}
+
 	response := GetPhoneNumberResponse{PhoneNumber: os.Getenv("CALLBOX_PHONE_NUMBER")}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
+
+	return
+}
+
+func (s *Server) GetPhoneNumber(w http.ResponseWriter, r *http.Request) {
+	if err := s.postCallboxSettings(w, r); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Error{Cause: err.Error()})
+	}
 }


### PR DESCRIPTION

https://github.com/oapi-codegen/oapi-codegen?tab=readme-ov-file#strict-server
---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #8683
* #8682