### PR TITLE
Add basic TypeScript gazelle extension

### DIFF
--- a/go/gazelle/ts/BUILD.bazel
+++ b/go/gazelle/ts/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//bzl:rules.bzl", "bazel_lint")
+load("//go:rules.bzl", "go_library")
+
+go_library(
+    name = "ts",
+    srcs = ["package.go"],
+    importpath = "github.com/zemn-me/monorepo/go/gazelle/ts",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_gazelle//config",
+        "@bazel_gazelle//label",
+        "@bazel_gazelle//language",
+        "@bazel_gazelle//repo",
+        "@bazel_gazelle//resolve",
+        "@bazel_gazelle//rule",
+        "@com_github_bazelbuild_buildtools//build",
+    ],
+)
+
+go_test(
+    name = "ts_test",
+    srcs = ["package_test.go"],
+    deps = [
+        ":ts",
+        "//go/gazelle/ts/testdata",
+        "@bazel_gazelle//config",
+        "@bazel_gazelle//language",
+        "@bazel_gazelle//resolve",
+        "@bazel_gazelle//rule",
+        "@com_github_bazelbuild_buildtools//build",
+    ],
+)
+
+bazel_lint(
+    name = "bazel_lint",
+    srcs = ["BUILD.bazel"],
+)
+

--- a/go/gazelle/ts/package.go
+++ b/go/gazelle/ts/package.go
@@ -1,0 +1,160 @@
+package ts
+
+import (
+	"flag"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/repo"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazelbuild/buildtools/build"
+)
+
+// Language implements a very small Gazelle extension that can
+// generate ts_project rules for .ts and .tsx files.
+type Language struct{}
+
+func (Language) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
+func (Language) CheckFlags(fs *flag.FlagSet, c *config.Config) error          { return nil }
+func (Language) KnownDirectives() []string                                    { return []string{} }
+func (Language) Configure(c *config.Config, rel string, f *rule.File)         {}
+func (Language) Name() string                                                 { return "typescript" }
+
+// regex used to find imported modules.
+var importRe = regexp.MustCompile(`(?m)^(?:import|export)[^\n]*?from\s+["']([^"']+)["']`)
+
+// listImports returns all import strings in a TypeScript file.
+func listImports(filename string) ([]string, error) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	matches := importRe.FindAllSubmatch(b, -1)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) > 1 {
+			out = append(out, string(m[1]))
+		}
+	}
+	return out, nil
+}
+
+type DepSet map[string]bool
+
+func isTsFile(name string) bool {
+	return path.Ext(name) == ".ts" || path.Ext(name) == ".tsx"
+}
+
+func ruleNameFromFile(name string) string {
+	return strings.ReplaceAll(name, ".", "_")
+}
+
+func generateRule(fileName string, args language.GenerateArgs) (*rule.Rule, DepSet, error) {
+	if !isTsFile(fileName) {
+		return nil, nil, nil
+	}
+	filePath := path.Join(args.Dir, fileName)
+	imports, err := listImports(filePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	deps := make(DepSet)
+	for _, i := range imports {
+		deps[i] = true
+	}
+	r := rule.NewRule("ts_project", ruleNameFromFile(fileName))
+	r.SetAttr("srcs", &build.ListExpr{List: []build.Expr{&build.StringExpr{Value: fileName}}})
+	return r, deps, nil
+}
+
+func (Language) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	var srcs *build.ListExpr
+	var ok bool
+	if srcs, ok = r.Attr("srcs").(*build.ListExpr); !ok {
+		return nil
+	}
+	var specs []resolve.ImportSpec
+	for _, src := range srcs.List {
+		specs = append(specs, resolve.ImportSpec{
+			Lang: "typescript",
+			Imp:  path.Join(f.Pkg, src.(*build.StringExpr).Value),
+		})
+	}
+	return specs
+}
+
+func (Language) Embeds(r *rule.Rule, from label.Label) []label.Label { return nil }
+
+func (Language) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
+	deps := make([]string, 0)
+	for dep := range imports.(DepSet) {
+		matches := ix.FindRulesByImportWithConfig(c, resolve.ImportSpec{Lang: "typescript", Imp: dep}, "typescript")
+		if len(matches) == 0 {
+			continue
+		}
+		deps = append(deps, matches[0].Label.String())
+	}
+	if len(deps) > 0 {
+		r.SetAttr("deps", deps)
+	}
+}
+
+func (Language) Kinds() map[string]rule.KindInfo {
+	return map[string]rule.KindInfo{
+		"ts_project": {
+			MatchAny:   true,
+			MatchAttrs: []string{"srcs"},
+			NonEmptyAttrs: map[string]bool{
+				"srcs": true,
+			},
+			MergeableAttrs: map[string]bool{
+				"srcs": true,
+				"deps": true,
+			},
+			ResolveAttrs: map[string]bool{
+				"deps": true,
+			},
+		},
+	}
+}
+
+func (Language) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+	var result language.GenerateResult
+	for _, f := range args.RegularFiles {
+		r, deps, err := generateRule(f, args)
+		if err != nil {
+			panic(err)
+		}
+		if r == nil {
+			continue
+		}
+		result.Gen = append(result.Gen, r)
+		result.Imports = append(result.Imports, deps)
+	}
+	return result
+}
+
+func (Language) Loads() []rule.LoadInfo {
+	panic("Call ApparentLoads")
+}
+
+var _ language.ModuleAwareLanguage = Language{}
+
+func (Language) ApparentLoads(moduleToApparentName func(string) string) []rule.LoadInfo {
+	return []rule.LoadInfo{
+		{
+			Name:    "//ts:rules.bzl",
+			Symbols: []string{"ts_project"},
+		},
+	}
+}
+
+func (Language) Fix(c *config.Config, f *rule.File) {}
+
+func NewLanguage() language.Language { return &Language{} }

--- a/go/gazelle/ts/package_test.go
+++ b/go/gazelle/ts/package_test.go
@@ -1,0 +1,89 @@
+package ts
+
+import (
+	"os"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	build "github.com/bazelbuild/buildtools/build"
+
+	testdata "github.com/zemn-me/monorepo/go/gazelle/ts/testdata"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(path.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListImports(t *testing.T) {
+	dir := t.TempDir()
+	fname := path.Join(dir, "main.ts")
+	writeFile(t, dir, "main.ts", testdata.ExampleFile)
+	imps, err := listImports(fname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"./foo", "./bar", "lib"}
+	if !reflect.DeepEqual(imps, want) {
+		t.Fatalf("imports=%v want %v", imps, want)
+	}
+}
+
+func TestGenerateRule(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.ts", testdata.ExampleFile)
+	args := language.GenerateArgs{Dir: dir}
+	r, deps, err := generateRule("main.ts", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r == nil {
+		t.Fatalf("expected rule")
+	}
+	if r.Kind() != "ts_project" {
+		t.Fatalf("kind %s", r.Kind())
+	}
+	srcs, ok := r.Attr("srcs").(*build.ListExpr)
+	if !ok || len(srcs.List) != 1 || srcs.List[0].(*build.StringExpr).Value != "main.ts" {
+		t.Fatalf("srcs not set correctly: %#v", r.Attr("srcs"))
+	}
+	exp := DepSet{"./foo": true, "./bar": true, "lib": true}
+	if !reflect.DeepEqual(deps, exp) {
+		t.Fatalf("deps=%v want %v", deps, exp)
+	}
+}
+
+func TestLanguageGenerateRules(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.ts", testdata.ExampleFile)
+	l := Language{}
+	args := language.GenerateArgs{Dir: dir, RegularFiles: []string{"main.ts"}}
+	res := l.GenerateRules(args)
+	if len(res.Gen) != 1 {
+		t.Fatalf("got %d rules", len(res.Gen))
+	}
+	if res.Gen[0].Kind() != "ts_project" {
+		t.Fatalf("kind %s", res.Gen[0].Kind())
+	}
+	if len(res.Imports) != 1 {
+		t.Fatalf("got %d imports", len(res.Imports))
+	}
+}
+
+func TestLanguageImports(t *testing.T) {
+	r := rule.NewRule("ts_project", "main_ts")
+	r.SetAttr("srcs", &build.ListExpr{List: []build.Expr{&build.StringExpr{Value: "main.ts"}}})
+	f := &rule.File{Pkg: "foo"}
+	specs := Language{}.Imports(&config.Config{}, r, f)
+	want := []resolve.ImportSpec{{Lang: "typescript", Imp: path.Join("foo", "main.ts")}}
+	if !reflect.DeepEqual(specs, want) {
+		t.Fatalf("imports=%v want %v", specs, want)
+	}
+}

--- a/go/gazelle/ts/testdata/BUILD.bazel
+++ b/go/gazelle/ts/testdata/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//bzl:rules.bzl", "bazel_lint")
+load("//go:rules.bzl", "go_library")
+
+go_library(
+    name = "testdata",
+    srcs = ["example.go"],
+    importpath = "github.com/zemn-me/monorepo/go/gazelle/ts/testdata",
+    visibility = ["//visibility:public"],
+)
+
+bazel_lint(
+    name = "bazel_lint",
+    srcs = ["BUILD.bazel"],
+)
+

--- a/go/gazelle/ts/testdata/example.go
+++ b/go/gazelle/ts/testdata/example.go
@@ -1,0 +1,6 @@
+package ts_testdata
+
+const ExampleFile = `import foo from "./foo";
+export { bar } from "./bar";
+import { baz } from "lib";
+`


### PR DESCRIPTION
## Summary
- add a minimal Gazelle language for TypeScript in `go/gazelle/ts`
- expose it via BUILD so it can be used by Gazelle
- add unit tests covering import parsing and rule generation

## Testing
- `go vet ./go/...` *(fails: environment has no network access)*