### PR TITLE
Fix typo in auth comment

### DIFF
--- a/project/zemn.me/app/auth/client.tsx
+++ b/project/zemn.me/app/auth/client.tsx
@@ -388,7 +388,7 @@ export default function Auth() {
 	)
 
 	/**
-	 * New new auth token cache with the newly recieved OIDC id_token
+        * New new auth token cache with the newly received OIDC id_token
 	 * mixed in.
 	 */
 	const amendedAuthTokenCache = result_and_then(


### PR DESCRIPTION
## Summary
- fix "received" typo in auth client comment

## Testing
- `./sh/bin/gazelle` *(fails: cannot find `ld`)*
- `./sh/bin/bazel test project/zemn.me/app/auth/...` *(fails during build)*

------
https://chatgpt.com/codex/tasks/task_e_6841d5eaf1c8832c9b7324dc743b2edb