### PR TITLE
Add security.txt to api.zemn.me

### DIFF
--- a/project/zemn.me/api/server/BUILD.bazel
+++ b/project/zemn.me/api/server/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("//bzl:rules.bzl", "bazel_lint")
 load("//bzl/go:oapi_codegen.bzl", "go_oapi_codegen")
@@ -20,6 +21,12 @@ go_oapi_codegen(
     source = "//project/zemn.me/api:spec.yaml",
 )
 
+copy_file(
+    name = "security_txt",
+    src = "//ts/pulumi/lib/website:security.txt",
+    out = "security.txt",
+)
+
 go_library(
     name = "server",
     srcs = [
@@ -33,9 +40,11 @@ go_library(
         "phone.go",
         "phone_hold_music.go",
         "phone_join_conference.go",
+        "security_txt.go",
         "server.go",
         "uuid.go",
     ],
+    embedsrcs = ["security.txt"],
     importpath = "github.com/zemn-me/monorepo/project/zemn.me/api/server",
     visibility = ["//visibility:public"],
     deps = [

--- a/project/zemn.me/api/server/security_txt.go
+++ b/project/zemn.me/api/server/security_txt.go
@@ -1,0 +1,17 @@
+package apiserver
+
+import (
+	"context"
+	_ "embed"
+)
+
+//go:embed security.txt
+var securityTxt string
+
+func (s *Server) GetSecurityTxt(ctx context.Context, rq GetSecurityTxtRequestObject) (GetSecurityTxtResponseObject, error) {
+	return GetSecurityTxt200TextResponse(securityTxt), nil
+}
+
+func (s *Server) GetWellKnownSecurityTxt(ctx context.Context, rq GetWellKnownSecurityTxtRequestObject) (GetWellKnownSecurityTxtResponseObject, error) {
+	return GetWellKnownSecurityTxt200TextResponse(securityTxt), nil
+}

--- a/project/zemn.me/api/spec.yaml
+++ b/project/zemn.me/api/spec.yaml
@@ -350,3 +350,28 @@ paths:
               schema:
                 type: string
                 enum: [OK]
+
+  /.well-known/security.txt:
+    get:
+      summary: security.txt
+      description: Security contact information.
+      responses:
+        "200":
+          description: security.txt contents.
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /security.txt:
+    get:
+      summary: security.txt
+      description: Security contact information.
+      responses:
+        "200":
+          description: security.txt contents.
+          content:
+            text/plain:
+              schema:
+                type: string
+

--- a/ts/pulumi/lib/website/BUILD.bazel
+++ b/ts/pulumi/lib/website/BUILD.bazel
@@ -1,6 +1,8 @@
 load("//bzl:rules.bzl", "bazel_lint")
 load("//ts:rules.bzl", "ts_project")
 
+exports_files(["security.txt"])
+
 ts_project(
     name = "website",
     data = ["security.txt"],


### PR DESCRIPTION
## Summary
- expose `.well-known/security.txt` and `/security.txt` from api.zemn.me
- embed same security.txt as other sites by copying it from the website package

## Testing
- `bazel test //project/zemn.me/api/server:server_test --test_output=errors`


------
https://chatgpt.com/codex/tasks/task_e_6852d768c18c832c8649139cdabc9686