### PR TITLE
Fix TypeScript check for end date

### DIFF
--- a/project/zemn.me/app/experiments/cv/page.tsx
+++ b/project/zemn.me/app/experiments/cv/page.tsx
@@ -26,14 +26,17 @@ type Event = (typeof Bio.timeline)[number];
 function WorkItem({ event }: { readonly event: Event }) {
         const start = ('since' in event && event.since ? event.since : event.date) as Date;
         const end = 'until' in event ? event.until : undefined;
-        const endDate = end instanceof Date ? end : undefined;
-        const employer = 'employer' in event ? event.employer : undefined;
-        return (
-                <div className={style.work} key={event.id}>
-                        {employer && <div className={style.employer}>{employer.text}</div>}
-                        <div className={style.position}>{event.title.text}</div>
-                        <div className={`${style.date} ${style.start}`}><time dateTime={String(+start)}>{start.getFullYear()}</time></div>
-                        {end && <div className={style.end}>{end === 'ongoing' ? 'Ongoing' : endDate?.getFullYear()}</div>}
+       const employer = 'employer' in event ? event.employer : undefined;
+       return (
+               <div className={style.work} key={event.id}>
+                       {employer && <div className={style.employer}>{employer.text}</div>}
+                       <div className={style.position}>{event.title.text}</div>
+                       <div className={`${style.date} ${style.start}`}><time dateTime={String(+start)}>{start.getFullYear()}</time></div>
+                       {end && (
+                               <div className={style.end}>
+                                       {typeof end === 'string' ? 'Ongoing' : end.getFullYear()}
+                               </div>
+                       )}
                         {'description' in event && event.description && (
                                 <span className={`${style.timelineDescription} ${style.content}`}>
                                         <p>{event.description.text}</p>


### PR DESCRIPTION
## Summary
- handle the `until` field properly when rendering the CV page

## Testing
- `bazel test //project/zemn.me/app/experiments/cv:cv_typecheck_test --test_output=errors`


------
https://chatgpt.com/codex/tasks/task_e_6852dbcfd67c832cb2df83746d8b2498