### PR TITLE
Add regression test for empty Digits query param

### DIFF
--- a/project/zemn.me/api/server/BUILD.bazel
+++ b/project/zemn.me/api/server/BUILD.bazel
@@ -76,15 +76,18 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "allow_empty_digits_test.go",
         "cors_test.go",
         "phone_features_test.go",
         "smoke_test.go",
     ],
     embed = [":server"],
     deps = [
+        "//project/zemn.me/api",
         "@com_github_aws_aws_sdk_go_v2_feature_dynamodb_attributevalue//:attributevalue",
         "@com_github_aws_aws_sdk_go_v2_service_dynamodb//:dynamodb",
         "@com_github_aws_aws_sdk_go_v2_service_dynamodb//types",
+        "@com_github_getkin_kin_openapi//openapi3",
         "@com_github_twilio_twilio_go//twiml",
     ],
 )

--- a/project/zemn.me/api/server/BUILD.bazel
+++ b/project/zemn.me/api/server/BUILD.bazel
@@ -83,11 +83,9 @@ go_test(
     ],
     embed = [":server"],
     deps = [
-        "//project/zemn.me/api",
         "@com_github_aws_aws_sdk_go_v2_feature_dynamodb_attributevalue//:attributevalue",
         "@com_github_aws_aws_sdk_go_v2_service_dynamodb//:dynamodb",
         "@com_github_aws_aws_sdk_go_v2_service_dynamodb//types",
-        "@com_github_getkin_kin_openapi//openapi3",
         "@com_github_twilio_twilio_go//twiml",
     ],
 )

--- a/project/zemn.me/api/server/allow_empty_digits_test.go
+++ b/project/zemn.me/api/server/allow_empty_digits_test.go
@@ -1,0 +1,39 @@
+package apiserver
+
+import (
+    "testing"
+
+    "github.com/getkin/kin-openapi/openapi3"
+    apiSpec "github.com/zemn-me/monorepo/project/zemn.me/api"
+)
+
+func TestSpecAllowsEmptyDigits(t *testing.T) {
+    loader := openapi3.NewLoader()
+    spec, err := loader.LoadFromData([]byte(apiSpec.Spec))
+    if err != nil {
+        t.Fatalf("failed to load spec: %v", err)
+    }
+
+    pathItem := spec.Paths.Find("/phone/handleEntry")
+    if pathItem == nil {
+        t.Fatalf("path /phone/handleEntry not found")
+    }
+    if pathItem.Get == nil {
+        t.Fatalf("GET operation missing on /phone/handleEntry")
+    }
+
+    var param *openapi3.ParameterRef
+    for _, p := range pathItem.Get.Parameters {
+        if p.Value != nil && p.Value.Name == "Digits" && p.Value.In == "query" {
+            param = p
+            break
+        }
+    }
+    if param == nil {
+        t.Fatalf("Digits query parameter not found")
+    }
+    if !param.Value.AllowEmptyValue {
+        t.Errorf("expected allowEmptyValue to be true for Digits param")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Go regression test ensuring Digits query param in /phone/handleEntry allows empty values
- update BUILD file for new test

## Testing
- `bazel test //project/zemn.me/api/server:server_test --test_output=errors --test_filter=TestSpecAllowsEmptyDigits`

------
https://chatgpt.com/codex/tasks/task_e_6852e942c304832c800ba81864bb725b