### PR TITLE
Add pnpm lockfile mismatch test

### DIFF
--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -34,6 +34,24 @@ go_test(
     srcs = ["go_basic_test.go"],
 )
 
+sh_test(
+    name = "pnpm_lockfile_validation_fail_test",
+    srcs = ["pnpm_lockfile_validation/test_fail.sh"],
+    data = [
+        "//:package.json",
+        "//:pnpm-lock.yaml",
+        "//:pnpm_lockfile_validation_bin",
+        "//sh/bin:gojq",
+    ],
+    env = {
+        "PACKAGE_JSON": "$(rlocationpath //:package.json)",
+        "PNPM_LOCKFILE": "$(rlocationpath //:pnpm-lock.yaml)",
+        "VALIDATION_BIN": "$(rlocationpath //:pnpm_lockfile_validation_bin)",
+        "GOJQ_BINARY": "$(rlocationpath //sh/bin:gojq)",
+    },
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
 bazel_lint(
     name = "bazel_lint",
     srcs = ["BUILD.bazel"],

--- a/testing/pnpm_lockfile_validation/test_fail.sh
+++ b/testing/pnpm_lockfile_validation/test_fail.sh
@@ -28,6 +28,6 @@ if $(rlocation $VALIDATION_BIN) >out.txt 2>&1; then
   cat out.txt >&2
   exit 1
 else
-  echo "command failed as expected" >&2
+  # command failed as expected; suppress output
   exit 0
 fi

--- a/testing/pnpm_lockfile_validation/test_fail.sh
+++ b/testing/pnpm_lockfile_validation/test_fail.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+set -euo pipefail
+
+# Bazel supplies TEST_TMPDIR for a writable workspace
+cp "$(rlocation $PACKAGE_JSON)" "$TEST_TMPDIR/package.json"
+cp "$(rlocation $PNPM_LOCKFILE)" "$TEST_TMPDIR/pnpm-lock.yaml"
+
+# Add a fake dependency to cause mismatch using jq
+$(rlocation $GOJQ_BINARY) '.devDependencies["pnpm-lockfile-validation-test"] = "0.0.1"' "$TEST_TMPDIR/package.json" > "$TEST_TMPDIR/package.json.tmp"
+mv "$TEST_TMPDIR/package.json.tmp" "$TEST_TMPDIR/package.json"
+
+cd "$TEST_TMPDIR"
+
+if $(rlocation $VALIDATION_BIN) >out.txt 2>&1; then
+  echo "expected failure but command succeeded" >&2
+  cat out.txt >&2
+  exit 1
+else
+  echo "command failed as expected" >&2
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- add a shell test to verify `pnpm_lockfile_validation_bin` fails when `package.json` is edited without updating `pnpm-lock.yaml`
- use gojq to add a dummy dependency rather than editing an existing one
- use Bazel's `TEST_TMPDIR` in the shell script
- wire the new test into `testing/BUILD.bazel`

## Testing
- `bazel test //testing:pnpm_lockfile_validation_fail_test`


------
https://chatgpt.com/codex/tasks/task_e_685300eace3c832c9c1cf034e9149709