### PR TITLE
Fix S3 lifecycle policy type

### DIFF
--- a/ts/pulumi/lib/expire_on_delete/expire_on_delete.ts
+++ b/ts/pulumi/lib/expire_on_delete/expire_on_delete.ts
@@ -142,7 +142,7 @@ export class S3ExpireOnDeletePolicy extends ComponentResource {
                             key: "soft_deleted",
                             value: "true",
                         },
-						objectSizeGreaterThan: '0',
+                        objectSizeGreaterThan: 0,
                     },
                     status: "Enabled",
                     expiration: {


### PR DESCRIPTION
## Summary
- correct type for `objectSizeGreaterThan` in expire_on_delete policy

## Testing
- `bazel build //ts/pulumi/lib/expire_on_delete:expire_on_delete`


------
https://chatgpt.com/codex/tasks/task_e_685595a69b24832c9aa315a169217413