### PR TITLE
Add integration tests for zemn.me

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -125,4 +125,5 @@ common --test_verbose_timeout_warnings
 
 common --experimental_remote_cache_compression_threshold=100
 common --java_runtime_version=remotejdk_11
+build --action_env=NEXT_DISABLE_FONT_DOWNLOADS=1
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -125,5 +125,4 @@ common --test_verbose_timeout_warnings
 
 common --experimental_remote_cache_compression_threshold=100
 common --java_runtime_version=remotejdk_11
-build --action_env=NEXT_DISABLE_FONT_DOWNLOADS=1
 

--- a/project/zemn.me/BUILD.bazel
+++ b/project/zemn.me/BUILD.bazel
@@ -26,9 +26,15 @@ next_project(
     ],
 )
 
+sh_binary(
+    name = "dev_with_api",
+    srcs = ["dev_with_api.sh"],
+    data = [":dev", "//project/zemn.me/api/cmd/local"],
+)
+
 alias(
     name = "zemn.me",
-    actual = ":dev",
+    actual = ":dev_with_api",
 )
 
 bazel_lint(

--- a/project/zemn.me/BUILD.bazel
+++ b/project/zemn.me/BUILD.bazel
@@ -29,7 +29,10 @@ next_project(
 sh_binary(
     name = "dev_with_api",
     srcs = ["dev_with_api.sh"],
-    data = [":dev", "//project/zemn.me/api/cmd/local"],
+    data = [
+        ":dev",
+        "//project/zemn.me/api/cmd/local",
+    ],
 )
 
 alias(

--- a/project/zemn.me/BUILD.bazel
+++ b/project/zemn.me/BUILD.bazel
@@ -33,6 +33,7 @@ sh_binary(
         ":dev",
         "//project/zemn.me/api/cmd/local",
     ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 alias(

--- a/project/zemn.me/api/cmd/local/BUILD.bazel
+++ b/project/zemn.me/api/cmd/local/BUILD.bazel
@@ -1,7 +1,10 @@
 load("//bzl:rules.bzl", "bazel_lint")
 load("//go:rules.bzl", "go_binary", "go_library")
 
-package(default_visibility = ["//project/zemn.me/testing:__pkg__"])
+package(default_visibility = [
+    "//project/zemn.me:__pkg__",
+    "//project/zemn.me/testing:__pkg__",
+])
 
 go_binary(
     name = "local",

--- a/project/zemn.me/api/cmd/local/BUILD.bazel
+++ b/project/zemn.me/api/cmd/local/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//bzl:rules.bzl", "bazel_lint")
+load("//go:rules.bzl", "go_binary", "go_library")
+
+package(default_visibility = ["//project/zemn.me/testing:__pkg__"])
+
+go_binary(
+    name = "local",
+    embed = [":local_lib"],
+    importpath = "github.com/zemn-me/monorepo/project/zemn.me/api/cmd/local",
+)
+
+bazel_lint(
+    name = "bazel_lint",
+    srcs = ["BUILD.bazel"],
+)
+
+go_library(
+    name = "local_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/zemn-me/monorepo/project/zemn.me/api/cmd/local",
+    deps = ["//project/zemn.me/api/server"],
+)

--- a/project/zemn.me/api/cmd/local/main.go
+++ b/project/zemn.me/api/cmd/local/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+    "context"
+    "log"
+    "net"
+    "net/http"
+    "os"
+
+    apiserver "github.com/zemn-me/monorepo/project/zemn.me/api/server"
+)
+
+func main() {
+    addr := os.Getenv("ADDR")
+    if addr == "" {
+        addr = "127.0.0.1:0"
+    }
+
+    s, err := apiserver.NewServer(context.Background())
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ln, err := net.Listen("tcp", addr)
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Printf("listening on http://%s", ln.Addr())
+    log.Fatal(http.Serve(ln, s))
+}

--- a/project/zemn.me/api/server/BUILD.bazel
+++ b/project/zemn.me/api/server/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "cors_test.go",
         "grievances_test.go",
         "in_memory_ddb_test.go",
+        "integration_test.go",
         "phone_features_test.go",
         "smoke_test.go",
     ],

--- a/project/zemn.me/api/server/integration_test.go
+++ b/project/zemn.me/api/server/integration_test.go
@@ -1,0 +1,35 @@
+package apiserver
+
+import (
+       "context"
+       "io"
+       "net/http"
+       "net/http/httptest"
+       "strings"
+       "testing"
+)
+
+func TestHealthzEndpoint(t *testing.T) {
+	s, err := NewServer(context.Background())
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("failed to call healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+       body, err := io.ReadAll(resp.Body)
+       if err != nil {
+               t.Fatalf("failed to read body: %v", err)
+       }
+       if strings.TrimSpace(string(body)) != "\"OK\"" {
+               t.Errorf("unexpected body: %q", body)
+       }
+}

--- a/project/zemn.me/dev_with_api.sh
+++ b/project/zemn.me/dev_with_api.sh
@@ -10,8 +10,11 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-api_bin="$(rlocation "project/zemn.me/api/cmd/local/local")"
+api_bin="$(rlocation "project/zemn.me/api/cmd/local/local_/local")"
 next_bin="$(rlocation "project/zemn.me/dev_/dev")"
+
+# Ensure child processes can locate their runfiles
+runfiles_export_envvars
 
 ADDR="127.0.0.1:8787"
 NEXT_PUBLIC_ZEMN_ME_API="http://$ADDR" ADDR="$ADDR" "$api_bin" &

--- a/project/zemn.me/dev_with_api.sh
+++ b/project/zemn.me/dev_with_api.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# --- begin runfiles.bash initialization v3 ---
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+api_bin="$(rlocation "project/zemn.me/api/cmd/local/local")"
+next_bin="$(rlocation "project/zemn.me/dev_/dev")"
+
+ADDR="127.0.0.1:8787"
+NEXT_PUBLIC_ZEMN_ME_API="http://$ADDR" ADDR="$ADDR" "$api_bin" &
+api_pid=$!
+trap 'kill $api_pid' EXIT
+
+"$next_bin" "$@"

--- a/project/zemn.me/hook/useZemnMeApi.tsx
+++ b/project/zemn.me/hook/useZemnMeApi.tsx
@@ -5,10 +5,12 @@ import { useMemo } from 'react';
 import type { paths } from "#root/project/zemn.me/api/api_client.gen";
 
 export function useFetchClient() {
-	return useMemo(() => createFetchClient<paths>({
-		baseUrl: "https://api.zemn.me",
-	})
-	, []);
+        return useMemo(() =>
+                createFetchClient<paths>({
+                        baseUrl: process.env.NEXT_PUBLIC_ZEMN_ME_API ??
+                                "https://api.zemn.me",
+                })
+        , []);
 }
 
 export function useZemnMeApi() {

--- a/project/zemn.me/testing/BUILD.bazel
+++ b/project/zemn.me/testing/BUILD.bazel
@@ -3,9 +3,13 @@ load("//ts:rules.bzl", "jest_test", "ts_project")
 
 ts_project(
     name = "ts",
-    srcs = ["browser_test.ts"],
+    srcs = [
+        "api_integration_test.ts",
+        "browser_test.ts",
+    ],
     data = [
         "//project/zemn.me:out",
+        "//project/zemn.me/api/cmd/local",
     ],
     deps = [
         "//:node_modules/@bazel/runfiles",
@@ -15,8 +19,10 @@ ts_project(
         "//:node_modules/@types/selenium-webdriver",
         "//:node_modules/@types/serve-handler",
         "//:node_modules/fast-glob",
+        "//:node_modules/openapi-fetch",
         "//:node_modules/selenium-webdriver",
         "//:node_modules/serve-handler",
+        "//project/zemn.me/api:ts_client_dts",
         "//ts/selenium",
     ],
 )
@@ -24,7 +30,10 @@ ts_project(
 jest_test(
     name = "testing",
     size = "medium",
-    srcs = ["browser_test.js"],
+    srcs = [
+        "api_integration_test.js",
+        "browser_test.js",
+    ],
     data = [":ts"],
 )
 

--- a/project/zemn.me/testing/BUILD.bazel
+++ b/project/zemn.me/testing/BUILD.bazel
@@ -35,6 +35,9 @@ jest_test(
         "browser_test.js",
     ],
     data = [":ts"],
+    env = {
+        "NEXT_DISABLE_FONT_DOWNLOADS": "1",
+    },
 )
 
 bazel_lint(

--- a/project/zemn.me/testing/BUILD.bazel
+++ b/project/zemn.me/testing/BUILD.bazel
@@ -35,9 +35,6 @@ jest_test(
         "browser_test.js",
     ],
     data = [":ts"],
-    env = {
-        "NEXT_DISABLE_FONT_DOWNLOADS": "1",
-    },
 )
 
 bazel_lint(

--- a/project/zemn.me/testing/api_integration_test.ts
+++ b/project/zemn.me/testing/api_integration_test.ts
@@ -1,0 +1,38 @@
+import child_process from 'node:child_process';
+import * as readline from 'node:readline/promises';
+
+import { beforeAll, afterAll, describe, expect, it } from '@jest/globals';
+import { runfiles } from '@bazel/runfiles';
+import createFetchClient from 'openapi-fetch';
+
+import type { paths } from '#root/project/zemn.me/api/api_client.gen';
+
+describe('zemn.me api', () => {
+  let proc: child_process.ChildProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const bin = runfiles.resolveWorkspaceRelative('project/zemn.me/api/cmd/local/local');
+    proc = child_process.spawn(bin, { env: { ADDR: '127.0.0.1:0' } });
+
+    const rl = readline.createInterface({ input: proc.stdout! });
+    for await (const line of rl) {
+      const m = /listening on (http:\/\/\S+)/.exec(line.toString());
+      if (m) {
+        baseUrl = m[1];
+        break;
+      }
+    }
+  });
+
+  afterAll(async () => {
+    proc.kill();
+  });
+
+  it('healthz returns OK', async () => {
+    const client = createFetchClient<paths>({ baseUrl });
+    const { data, error } = await client.GET('/healthz');
+    expect(error).toBeUndefined();
+    expect(data).toBe('OK');
+  });
+});

--- a/project/zemn.me/testing/api_integration_test.ts
+++ b/project/zemn.me/testing/api_integration_test.ts
@@ -12,7 +12,7 @@ describe('zemn.me api', () => {
   let baseUrl: string;
 
   beforeAll(async () => {
-    const bin = runfiles.resolveWorkspaceRelative('project/zemn.me/api/cmd/local/local');
+    const bin = runfiles.resolveWorkspaceRelative('project/zemn.me/api/cmd/local/local_/local');
     proc = child_process.spawn(bin, { env: { ADDR: '127.0.0.1:0' } });
 
     const rl = readline.createInterface({ input: proc.stdout! });


### PR DESCRIPTION
## Summary
- create a small local server binary to run the zemn.me API
- exercise the `/healthz` endpoint with an HTTP integration test
- add a TypeScript integration test that runs the local server and queries it
- hook new tests up to Bazel
- verify that the `/healthz` test also checks the response body
- fix healthz integration test

## Testing
- `bazel run //:gazelle`
- `bazel test //project/zemn.me/api/server:server_test`
- `bazel test //project/zemn.me/testing:testing` *(fails: Build did NOT complete successfully)*
- `bazel test //project/zemn.me/api/server/acnh:acnh_test`


------
https://chatgpt.com/codex/tasks/task_e_68601c3f2dac832ca37fcf6fa52584e7