### PR TITLE
Fix IAM policy for grievances table access

### DIFF
--- a/ts/pulumi/zemn.me/api/api.ts
+++ b/ts/pulumi/zemn.me/api/api.ts
@@ -60,12 +60,14 @@ export class ApiZemnMe extends Pulumi.ComponentResource {
 				policy: dynamoTable.arn.apply(arn => JSON.stringify({
 					Version: "2012-10-17",
 					Statement: [{
-						Action: [
-							"dynamodb:Query",
-							"dynamodb:PutItem",
-							"dynamodb:UpdateItem",
-							"dynamodb:DeleteItem"
-						],
+                                                Action: [
+                                                        "dynamodb:Query",
+                                                        "dynamodb:PutItem",
+                                                        "dynamodb:UpdateItem",
+                                                        "dynamodb:DeleteItem",
+                                                        "dynamodb:GetItem",
+                                                        "dynamodb:Scan"
+                                                ],
 						Effect: "Allow",
 						Resource: arn,
 					}],


### PR DESCRIPTION
## Summary
- allow DynamoDB Scan and GetItem for api server Lambda role

## Testing
- `bazel test //ts/pulumi/zemn.me/api:api_lint //ts/pulumi/zemn.me/api:api_typecheck_test //ts/pulumi/zemn.me/api:bazel_lint` *(fails: Failed to query remote execution capabilities)*
- `gazelle` *(fails: Failed to query remote execution capabilities)*

------
https://chatgpt.com/codex/tasks/task_e_68603e0ee3a8832cbc5b531eba71e258