### PR TITLE
Add endpoint to expose OIDC subject

### DIFF
--- a/project/zemn.me/api/server/BUILD.bazel
+++ b/project/zemn.me/api/server/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
     name = "server",
     srcs = [
         "TestRemoveDuplicateDigits.go",
+        "admin.go",
         "api.gen.go",
         "callbox_settings.go",
         "constants.go",
@@ -77,6 +78,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "admin_test.go",
         "allow_empty_digits_test.go",
         "cors_test.go",
         "grievances_test.go",
@@ -86,6 +88,7 @@ go_test(
     ],
     embed = [":server"],
     deps = [
+        "//project/zemn.me/api/server/auth",
         "@com_github_aws_aws_sdk_go_v2_feature_dynamodb_attributevalue//:attributevalue",
         "@com_github_aws_aws_sdk_go_v2_service_dynamodb//:dynamodb",
         "@com_github_aws_aws_sdk_go_v2_service_dynamodb//types",

--- a/project/zemn.me/api/server/admin.go
+++ b/project/zemn.me/api/server/admin.go
@@ -1,0 +1,17 @@
+package apiserver
+
+import (
+        "context"
+
+        "github.com/zemn-me/monorepo/project/zemn.me/api/server/auth"
+)
+
+// GetAdminUid returns the OIDC subject ID associated with the request.
+func (s *Server) GetAdminUid(ctx context.Context, rq GetAdminUidRequestObject) (GetAdminUidResponseObject, error) {
+        sub, ok := auth.SubjectFromContext(ctx)
+        if !ok {
+                return nil, nil
+        }
+        return GetAdminUid200TextResponse(sub), nil
+}
+

--- a/project/zemn.me/api/server/admin_test.go
+++ b/project/zemn.me/api/server/admin_test.go
@@ -1,0 +1,21 @@
+package apiserver
+
+import (
+        "context"
+        "testing"
+
+        "github.com/zemn-me/monorepo/project/zemn.me/api/server/auth"
+)
+
+func TestGetAdminUid(t *testing.T) {
+        s := newTestServer()
+        ctx := context.WithValue(context.Background(), auth.SubjectKey, "12345")
+        resp, err := s.GetAdminUid(ctx, GetAdminUidRequestObject{})
+        if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+        }
+        if string(resp.(GetAdminUid200TextResponse)) != "12345" {
+                t.Fatalf("unexpected response: %v", resp)
+        }
+}
+

--- a/project/zemn.me/api/spec.yaml
+++ b/project/zemn.me/api/spec.yaml
@@ -514,3 +514,16 @@ paths:
               schema:
                 type: string
 
+  /admin/uid:
+    get:
+      summary: Returns the caller's OIDC subject ID.
+      security:
+        - googleOIDC: []
+      responses:
+        "200":
+          description: The subject identifier.
+          content:
+            text/plain:
+              schema:
+                type: string
+


### PR DESCRIPTION
## Summary
- implement new `/admin/uid` endpoint to return caller's OIDC subject
- store subject in context during authentication
- expose helper for retrieving subject
- include basic unit test

## Testing
- `bazel test //project/zemn.me/api/server:server_test` *(fails: Build did NOT complete successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6860771fc710832ca5333932d1221353