### PR TITLE
Add creation timestamp to grievance entries

### DIFF
--- a/project/zemn.me/api/spec.yaml
+++ b/project/zemn.me/api/spec.yaml
@@ -202,6 +202,7 @@ components:
         - name
         - description
         - priority
+        - created
       properties:
         id:
           type: string
@@ -214,6 +215,9 @@ components:
           type: integer
           minimum: 1
           maximum: 10
+        created:
+          type: string
+          format: date-time
     NewGrievance:
       type: object
       required:

--- a/project/zemn.me/app/grievanceportal/client.tsx
+++ b/project/zemn.me/app/grievanceportal/client.tsx
@@ -13,6 +13,7 @@ import { ID_Token } from "#root/ts/oidc/oidc.js";
 import { and_then as option_and_then, flatten as option_flatten, None, Option, option_result_transpose, Some, unwrap_or as option_unwrap_or, unwrap_or_else as option_unwrap_or_else } from "#root/ts/option/types.js";
 import { queryResult } from "#root/ts/result/react-query/queryResult.js";
 import { and_then as result_and_then, Err, or_else as result_or_else, unwrap_or as result_unwrap_or, unwrap_or_else as result_unwrap_or_else } from "#root/ts/result/result.js";
+import { Date as PrettyDate } from "#root/ts/react/lang/date.js";
 
 import style from './style.module.css';
 
@@ -111,15 +112,16 @@ function GrievanceEditor({ Authorization }: GrievanceEditorProps) {
                         {option_unwrap_or(option_and_then(
                                 grievances,
                                 r => result_unwrap_or(r, []).map((g: Grievance) => (
-                                        <li key={g.id}>
-                                                <strong>{g.name}</strong>
-                                                {" ("}{severityMap.get(g.priority) ?? `level ${g.priority}`}{")"}
-                                                <p>{g.description}</p>
+                                       <li key={g.id}>
+                                               <strong>{g.name}</strong>
+                                               {" ("}{severityMap.get(g.priority) ?? `level ${g.priority}`}{")"}
+                                               <p><PrettyDate date={new Date(g.created)} /> {new Date(g.created).toLocaleTimeString()}</p>
+                                               <p>{g.description}</p>
                                                <button className={style.deleteButton} onClick={() => void del.mutate({
                                                         params: { path: { id: g.id! } },
                                                         headers: { Authorization }
                                                })}>Delete</button>
-                                        </li>
+                                       </li>
                                 ))
                         ), null)}
                 </ul>


### PR DESCRIPTION
## Summary
- track when grievances were created via new `created` field
- display the creation date on the grievance portal
- keep created timestamp stable on updates
- test for created timestamp persistence

## Testing
- `bazel test //project/zemn.me/api/server:server_test`

------
https://chatgpt.com/codex/tasks/task_e_686080ee592c832c8a6fb25a059fc87d