### PR TITLE
Allow second oidc subject

### DIFF
--- a/project/zemn.me/api/server/auth/oidc.go
+++ b/project/zemn.me/api/server/auth/oidc.go
@@ -62,8 +62,9 @@ func OIDC(ctx context.Context, ai *openapi3filter.AuthenticationInput) (err erro
 		return fmt.Errorf("invalid issuer: %s", claims.Iss)
 	}
 
-        if claims.Sub != "111669004071516300752" {
-                fmt.Errorf("unauthorized subject: %s", claims.Email)
+        if claims.Sub != "111669004071516300752" &&
+                claims.Sub != "112149295011396650000" {
+                return fmt.Errorf("unauthorized subject: %s", claims.Email)
         }
 
         r := ai.RequestValidationInput.Request


### PR DESCRIPTION
## Summary
- allow login with alternate OIDC UID 112149295011396650000

## Testing
- `bazel test //project/zemn.me/api/server:server_test //project/zemn.me/api/server/acnh:acnh_test`

------
https://chatgpt.com/codex/tasks/task_e_6860975cc180832c91f83ce72a59ad74