### PR TITLE
Add metadata for grievance portal page

### DIFF
--- a/project/zemn.me/app/grievanceportal/BUILD.bazel
+++ b/project/zemn.me/app/grievanceportal/BUILD.bazel
@@ -16,6 +16,7 @@ ts_project(
         "//:base_defs",
         "//:node_modules/@hookform/resolvers",
         "//:node_modules/@tanstack/react-query",
+        "//:node_modules/next",
         "//:node_modules/react-hook-form",
         "//:node_modules/zod",
         "//project/zemn.me/api:ts_client_dts",

--- a/project/zemn.me/app/grievanceportal/page.tsx
+++ b/project/zemn.me/app/grievanceportal/page.tsx
@@ -1,5 +1,12 @@
+import { Metadata } from 'next/types';
+
 import GrievancePortal from "#root/project/zemn.me/app/grievanceportal/client.js";
 
 export default function Page() {
         return <GrievancePortal />;
 }
+
+export const metadata: Metadata = {
+        title: 'Grievance Portal',
+        description: 'Submit and track grievances.',
+};


### PR DESCRIPTION
## Summary
- add a Next.js metadata export for the grievance portal page
- include `next` dependency in the grievance portal build rule

## Testing
- `bazel test //project/zemn.me/app/grievanceportal:all`


------
https://chatgpt.com/codex/tasks/task_e_6860a657a7ac832cb2d118710cc8d365