### PR TITLE
Fix auth unmarshaling issue

### DIFF
--- a/project/zemn.me/api/server/auth/oidc.go
+++ b/project/zemn.me/api/server/auth/oidc.go
@@ -49,10 +49,9 @@ func OIDC(ctx context.Context, ai *openapi3filter.AuthenticationInput) (err erro
 		return fmt.Errorf("token verification failed: %w", err)
 	}
 
-	var claim Identity
-
-	if err := token.Claims(&claim); err != nil {
-		return fmt.Errorf("failed to parse claims: %w", err)
+	claim := Identity{
+		Issuer:  token.Issuer,
+		Subject: token.Subject,
 	}
 
 	idIdx := slices.IndexFunc(AuthorizedUsers, func(u Identity) bool {


### PR DESCRIPTION

security requirements failed: failed to parse claims: json: cannot unmarshal object into Go value of type *auth.Identity
