### PR TITLE
Accept call with any digit

### DIFF
--- a/project/zemn.me/api/server/phone_features_test.go
+++ b/project/zemn.me/api/server/phone_features_test.go
@@ -37,11 +37,11 @@ func TestPostPhoneJoinConference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to encode xml: %v", err)
 	}
-	if !strings.Contains(xmlData, "<Gather") ||
-		!strings.Contains(xmlData, "Press 1 to accept this call") ||
-		!strings.Contains(xmlData, "attempt=1") {
-		t.Errorf("unexpected xml: %s", xmlData)
-	}
+       if !strings.Contains(xmlData, "<Gather") ||
+               !strings.Contains(xmlData, "Press any number to accept this call") ||
+               !strings.Contains(xmlData, "attempt=1") {
+               t.Errorf("unexpected xml: %s", xmlData)
+       }
 }
 
 func TestPostPhoneJoinConferenceDigitsAccepted(t *testing.T) {
@@ -66,6 +66,30 @@ func TestPostPhoneJoinConferenceDigitsAccepted(t *testing.T) {
 	if !strings.Contains(xmlData, "<Conference") || !strings.Contains(xmlData, TWILIO_CONFERENCE_NAME) {
 		t.Errorf("unexpected xml: %s", xmlData)
 	}
+}
+
+func TestPostPhoneJoinConferenceOtherDigitAccepted(t *testing.T) {
+       s := newTestServer()
+       digit := "7"
+       rq := PostPhoneJoinConferenceRequestObject{
+               Params: PostPhoneJoinConferenceParams{Secret: "secret"},
+               Body:   &TwilioCallRequest{Digits: &digit},
+       }
+       rs, err := s.postPhoneJoinConference(context.Background(), rq)
+       if err != nil {
+               t.Fatalf("unexpected error: %v", err)
+       }
+       resp, ok := rs.(TwimlResponse)
+       if !ok {
+               t.Fatalf("expected TwimlResponse, got %T", rs)
+       }
+       xmlData, err := twiml.ToXML(resp.Document)
+       if err != nil {
+               t.Fatalf("failed to encode xml: %v", err)
+       }
+       if !strings.Contains(xmlData, "<Conference") || !strings.Contains(xmlData, TWILIO_CONFERENCE_NAME) {
+               t.Errorf("unexpected xml: %s", xmlData)
+       }
 }
 
 func TestPostPhoneHoldMusic(t *testing.T) {

--- a/project/zemn.me/api/server/phone_join_conference.go
+++ b/project/zemn.me/api/server/phone_join_conference.go
@@ -1,52 +1,52 @@
 package apiserver
 
 import (
-        "context"
-        "fmt"
-        "net/url"
-        "os"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
 
-        twilioApi "github.com/twilio/twilio-go/rest/api/v2010"
-        "github.com/twilio/twilio-go/twiml"
+	twilioApi "github.com/twilio/twilio-go/rest/api/v2010"
+	"github.com/twilio/twilio-go/twiml"
 )
 
 const TWILIO_CONFERENCE_NAME = "CallboxConference"
 
 func (s *Server) postPhoneJoinConference(ctx context.Context, rq PostPhoneJoinConferenceRequestObject) (rs PostPhoneJoinConferenceResponseObject, err error) {
-        if err = s.TestTwilioChallenge(rq.Params.Secret); err != nil {
-                return
-        }
+	if err = s.TestTwilioChallenge(rq.Params.Secret); err != nil {
+		return
+	}
 
-        attempt := 1
-        if rq.Params.Attempt != nil {
-                attempt = *rq.Params.Attempt
-        }
+	attempt := 1
+	if rq.Params.Attempt != nil {
+		attempt = *rq.Params.Attempt
+	}
 
-        if rq.Body == nil || rq.Body.Digits == nil {
-                doc, response := twiml.CreateDocument()
-                gather := response.CreateElement("Gather")
-                gather.CreateAttr("action", fmt.Sprintf("/phone/join-conference?secret=%s&attempt=%d", url.QueryEscape(rq.Params.Secret), attempt))
-                gather.CreateAttr("method", "POST")
-                gather.CreateAttr("numDigits", "1")
-                gather.CreateAttr("timeout", "20")
-                gather.CreateAttr("actionOnEmptyResult", "true")
-                gather.CreateElement("Say").SetText("Press 1 to accept this call")
-                return TwimlResponse{Document: doc}, nil
-        }
+	if rq.Body == nil || rq.Body.Digits == nil {
+		doc, response := twiml.CreateDocument()
+		gather := response.CreateElement("Gather")
+		gather.CreateAttr("action", fmt.Sprintf("/phone/join-conference?secret=%s&attempt=%d", url.QueryEscape(rq.Params.Secret), attempt))
+		gather.CreateAttr("method", "POST")
+		gather.CreateAttr("numDigits", "1")
+		gather.CreateAttr("timeout", "20")
+		gather.CreateAttr("actionOnEmptyResult", "true")
+		gather.CreateElement("Say").SetText("Press any number to accept this call")
+		return TwimlResponse{Document: doc}, nil
+	}
 
-       if *rq.Body.Digits != "1" {
-               if attempt < 2 {
-                       cp := &twilioApi.CreateCallParams{}
-                       cp.SetTo(rq.Body.To)
-                       cp.SetFrom(os.Getenv("CALLBOX_PHONE_NUMBER"))
-                       cp.SetUrl(fmt.Sprintf("https://api.zemn.me/phone/join-conference?secret=%s&attempt=2", url.QueryEscape(rq.Params.Secret)))
-                       s.twilioClient.Api.CreateCall(cp)
-               }
-               doc, response := twiml.CreateDocument()
-               response.CreateElement("Say").SetText("No input detected. Goodbye")
-               response.CreateElement("Hangup")
-               return TwimlResponse{Document: doc}, nil
-       }
+	if len(*rq.Body.Digits) == 0 {
+		if attempt < 2 {
+			cp := &twilioApi.CreateCallParams{}
+			cp.SetTo(rq.Body.To)
+			cp.SetFrom(os.Getenv("CALLBOX_PHONE_NUMBER"))
+			cp.SetUrl(fmt.Sprintf("https://api.zemn.me/phone/join-conference?secret=%s&attempt=2", url.QueryEscape(rq.Params.Secret)))
+			s.twilioClient.Api.CreateCall(cp)
+		}
+		doc, response := twiml.CreateDocument()
+		response.CreateElement("Say").SetText("No input detected. Goodbye")
+		response.CreateElement("Hangup")
+		return TwimlResponse{Document: doc}, nil
+	}
 
 	doc, response := twiml.CreateDocument()
 	dial := response.CreateElement("Dial")


### PR DESCRIPTION
## Summary
- update Twilio prompt to instruct callers to press any number
- allow any digit input so long as it is present
- adjust tests accordingly

## Testing
- `bazel run //:gazelle`
- `bazel test //project/zemn.me/api/server:server_test`


------
https://chatgpt.com/codex/tasks/task_e_6862ab454d74832c868209995a97696a