### PR TITLE
Fix grievance sort order

### DIFF
--- a/project/zemn.me/app/grievanceportal/client.tsx
+++ b/project/zemn.me/app/grievanceportal/client.tsx
@@ -111,7 +111,10 @@ function GrievanceEditor({ Authorization }: GrievanceEditorProps) {
                 <ul className={style.grievanceList}>
                         {option_unwrap_or(option_and_then(
                                 grievances,
-                                r => result_unwrap_or(r, []).map((g: Grievance) => (
+                                r => result_unwrap_or(r, [])
+                                        .slice()
+                                        .sort((a, b) => new Date(b.created).valueOf() - new Date(a.created).valueOf())
+                                        .map((g: Grievance) => (
                                        <li key={g.id}>
                                                <strong>{g.name}</strong>
                                                {" ("}{severityMap.get(g.priority) ?? `level ${g.priority}`}{")"}


### PR DESCRIPTION
## Summary
- sort grievance items by `created` time, newest first

## Testing
- `bazel test //project/zemn.me/app/grievanceportal:all`


------
https://chatgpt.com/codex/tasks/task_e_6862c41ab02c832cb0130370d82855d7