### PR TITLE
fix grievanceportal description render

### DIFF
--- a/project/zemn.me/app/grievanceportal/client.tsx
+++ b/project/zemn.me/app/grievanceportal/client.tsx
@@ -116,7 +116,7 @@ function GrievanceEditor({ Authorization }: GrievanceEditorProps) {
                                                <strong>{g.name}</strong>
                                                {" ("}{severityMap.get(g.priority) ?? `level ${g.priority}`}{")"}
                                                <p><PrettyDate date={new Date(g.created)} /> {new Date(g.created).toLocaleTimeString()}</p>
-                                               <p>{g.description}</p>
+                                               <pre>{g.description}</pre>
                                                <button className={style.deleteButton} onClick={() => void del.mutate({
                                                         params: { path: { id: g.id! } },
                                                         headers: { Authorization }


### PR DESCRIPTION
## Summary
- preserve newline formatting of grievance descriptions

## Testing
- `sh/bin/gazelle -h` *(fails: Analyzing target)*
- `bazel test project/zemn.me/app/grievanceportal/... --test_output=errors` *(fails: Build did NOT complete successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6862c6363bf0832ca61435c42f66df71