### PR TITLE
Add healthz browser test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Changes must be tested via bazel test path/to/your/changes/...
 Bazel WILL take a long time! please don't interrupt the process! let it time out naturally...
 
 If your tests take too long, you can use `bazel query` to pick a more specific set of tests!
+In-browser tests depend on Node modules from npm. Without network access or pre-cached modules, `bazel test` may fail.
 
 # generated files
 

--- a/project/zemn.me/api/cmd/localserver/BUILD.bazel
+++ b/project/zemn.me/api/cmd/localserver/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//bzl:rules.bzl", "bazel_lint")
+load("//go:rules.bzl", "go_binary", "go_library")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "localserver_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/zemn-me/monorepo/project/zemn.me/api/cmd/localserver",
+    visibility = ["//visibility:private"],
+    deps = ["//project/zemn.me/api/server"],
+)
+
+bazel_lint(
+    name = "bazel_lint",
+    srcs = ["BUILD.bazel"],
+)
+
+go_binary(
+    name = "localserver",
+    embed = [":localserver_lib"],
+)

--- a/project/zemn.me/api/cmd/localserver/main.go
+++ b/project/zemn.me/api/cmd/localserver/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "net"
+    "net/http"
+
+    apiserver "github.com/zemn-me/monorepo/project/zemn.me/api/server"
+)
+
+func main() {
+    srv, err := apiserver.NewServer(context.Background())
+    if err != nil {
+        log.Fatalf("failed to create server: %v", err)
+    }
+
+    ln, err := net.Listen("tcp", ":0")
+    if err != nil {
+        log.Fatalf("listen: %v", err)
+    }
+    addr := ln.Addr().(*net.TCPAddr)
+    fmt.Printf("PORT=%d\n", addr.Port)
+    if err := http.Serve(ln, srv); err != nil {
+        log.Fatalf("serve: %v", err)
+    }
+}

--- a/project/zemn.me/testing/BUILD.bazel
+++ b/project/zemn.me/testing/BUILD.bazel
@@ -25,7 +25,10 @@ jest_test(
     name = "testing",
     size = "medium",
     srcs = ["browser_test.js"],
-    data = [":ts"],
+    data = [
+        ":ts",
+        "//project/zemn.me/api/cmd/localserver",
+    ],
 )
 
 bazel_lint(

--- a/project/zemn.me/testing/browser_test.ts
+++ b/project/zemn.me/testing/browser_test.ts
@@ -1,10 +1,11 @@
 import http from 'node:http';
 import Path from 'node:path';
+import { spawn, ChildProcess } from 'node:child_process';
 
 import { runfiles } from '@bazel/runfiles';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import glob from 'fast-glob';
-import { Browser, ThenableWebDriver } from 'selenium-webdriver';
+import { Browser, By, ThenableWebDriver } from 'selenium-webdriver';
 import handler from 'serve-handler';
 
 import { Driver } from '#root/ts/selenium/webdriver.js';
@@ -16,37 +17,55 @@ const pathsThatMayError = new Set(['healthcheck/bad', 'poc/c/']);
 
 describe('zemn.me website', () => {
 	describe('Endpoint Tests', () => {
-		let server: http.Server;
-		let origin: string;
-		let driver: ThenableWebDriver;
+                let server: http.Server;
+                let origin: string;
+                let apiProc: ChildProcess;
+                let apiOrigin: string;
+                let driver: ThenableWebDriver;
 		const paths = glob.sync(Path.join(base, '/**/*.html')).map(path =>
 			Path.relative(base, path).replace(/index.html|.html$/g, '')
 		);
 		paths.sort();
 
-		beforeAll(async () => {
-			server = http.createServer((rq, rw) => {
-				void handler(rq, rw, { public: base });
-			}).listen();
+                beforeAll(async () => {
+                        server = http.createServer((rq, rw) => {
+                                void handler(rq, rw, { public: base });
+                        }).listen();
 
-			const addressInfo = server.address();
+                        const addressInfo = server.address();
 
-			if (addressInfo == null || typeof addressInfo === 'string') {
-				throw new Error('Not AddressInfo');
-			}
+                        if (addressInfo == null || typeof addressInfo === 'string') {
+                                throw new Error('Not AddressInfo');
+                        }
 
-			origin = `http://localhost:${addressInfo.port}`;
-		});
+                        origin = `http://localhost:${addressInfo.port}`;
+
+                        const apiBin = runfiles.resolveWorkspaceRelative(
+                                'project/zemn.me/api/cmd/localserver/localserver'
+                        );
+                        apiProc = spawn(apiBin);
+                        apiOrigin = await new Promise<string>((resolve, reject) => {
+                                apiProc.stdout?.on('data', chunk => {
+                                        const m = /PORT=(\d+)/.exec(chunk.toString());
+                                        if (m) {
+                                                resolve(`http://localhost:${m[1]}`);
+                                        }
+                                });
+                                apiProc.once('error', reject);
+                                setTimeout(() => reject(new Error('api server did not start')), 10000);
+                        });
+                });
 
 		beforeEach(async () => {
 			driver = Driver().forBrowser(Browser.CHROME).build();
 		});
 
-		afterAll(async () => {
-			await new Promise<void>((resolve, reject) => {
-				server.close(err => (err ? reject(err) : resolve()));
-			});
-		});
+                afterAll(async () => {
+                        apiProc.kill();
+                        await new Promise<void>((resolve, reject) => {
+                                server.close(err => (err ? reject(err) : resolve()));
+                        });
+                });
 
 		const testEndpoint = async (endpoint: string) => {
 			try {
@@ -63,13 +82,23 @@ describe('zemn.me website', () => {
 			}
 		};
 
-		it.each(paths)('/%s should have no errors', async path => {
-			const logs = await testEndpoint(path);
-			if (pathsThatMayError.has(path)) return;
-			expect(logs).toHaveLength(
-				0
-			);
-		});
-	});
+                it.each(paths)('/%s should have no errors', async path => {
+                        const logs = await testEndpoint(path);
+                        if (pathsThatMayError.has(path)) return;
+                        expect(logs).toHaveLength(
+                                0
+                        );
+                });
+
+                it('api server /healthz returns OK', async () => {
+                        try {
+                                await driver.get(`${apiOrigin}/healthz`);
+                                const body = await driver.findElement(By.css('body')).getText();
+                                expect(body).toBe('"OK"');
+                        } finally {
+                                await driver.quit();
+                        }
+                });
+        });
 
 });

--- a/project/zemn.me/testing/browser_test.ts
+++ b/project/zemn.me/testing/browser_test.ts
@@ -41,7 +41,7 @@ describe('zemn.me website', () => {
                         origin = `http://localhost:${addressInfo.port}`;
 
                         const apiBin = runfiles.resolveWorkspaceRelative(
-                                'project/zemn.me/api/cmd/localserver/localserver'
+                                'project/zemn.me/api/cmd/localserver/localserver_/localserver'
                         );
                         apiProc = spawn(apiBin);
                         apiOrigin = await new Promise<string>((resolve, reject) => {
@@ -61,7 +61,7 @@ describe('zemn.me website', () => {
 		});
 
                 afterAll(async () => {
-                        apiProc.kill();
+                        apiProc?.kill();
                         await new Promise<void>((resolve, reject) => {
                                 server.close(err => (err ? reject(err) : resolve()));
                         });


### PR DESCRIPTION
## Summary
- include Selenium `By` in browser tests
- start local Go server for API
- check API `/healthz` returns `OK`
- document npm requirement for browser tests

## Testing
- `bazel run //:gazelle`
- `bazel test //project/zemn.me/testing:testing` *(fails: Build did NOT complete successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6865c1f447b8832c823dd70d97a1122f