### PR TITLE
Add start target to next_project

### DIFF
--- a/project/zemn.me/app/layout.tsx
+++ b/project/zemn.me/app/layout.tsx
@@ -33,9 +33,9 @@ const csp = {
 }
 
 export function RootLayout({ children }: Props) {
-	return (
-		<>
-		<Providers>
+        return (
+                <>
+                <Providers apiBaseUrl={process.env.NEXT_PUBLIC_ZEMN_ME_API_BASE}>
 			<html>
 				<head>
 					<link href="/icon.svg" rel="icon" type="image/svg+xml" />

--- a/project/zemn.me/app/providers.tsx
+++ b/project/zemn.me/app/providers.tsx
@@ -3,19 +3,23 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
 
 import { LocalStorageController } from '#root/project/zemn.me/hook/useLocalStorage.js';
+import { ApiBaseProvider } from '#root/project/zemn.me/hook/useZemnMeApi.js';
 
 export interface ProviderProps {
-	readonly children?: ReactNode;
+        readonly children?: ReactNode;
+        readonly apiBaseUrl?: string;
 }
 
 const queryClient = new QueryClient();
 
-export function Providers({ children }: ProviderProps) {
-	return (
-		<LocalStorageController>
-			<QueryClientProvider client={queryClient}>
-				{children}
-			</QueryClientProvider>
-		</LocalStorageController>
-	);
+export function Providers({ children, apiBaseUrl }: ProviderProps) {
+        return (
+                <LocalStorageController>
+                        <QueryClientProvider client={queryClient}>
+                                <ApiBaseProvider baseUrl={apiBaseUrl}>
+                                        {children}
+                                </ApiBaseProvider>
+                        </QueryClientProvider>
+                </LocalStorageController>
+        );
 }

--- a/project/zemn.me/hook/useZemnMeApi.tsx
+++ b/project/zemn.me/hook/useZemnMeApi.tsx
@@ -1,14 +1,36 @@
 import createFetchClient from "openapi-fetch";
 import createClient from "openapi-react-query";
-import { useMemo } from 'react';
+import { createContext, ReactNode, useContext, useMemo } from 'react';
 
 import type { paths } from "#root/project/zemn.me/api/api_client.gen";
 
+const DEFAULT_BASE_URL = "https://api.zemn.me";
+
+const ApiBaseContext = createContext<string>(
+        process.env.NEXT_PUBLIC_ZEMN_ME_API_BASE ?? DEFAULT_BASE_URL,
+);
+
+export interface ApiBaseProviderProps {
+        readonly baseUrl?: string;
+        readonly children?: ReactNode;
+}
+
+export function ApiBaseProvider({ baseUrl, children }: ApiBaseProviderProps) {
+        return <ApiBaseContext.Provider value={baseUrl ?? process.env.NEXT_PUBLIC_ZEMN_ME_API_BASE ?? DEFAULT_BASE_URL}>
+                {children}
+        </ApiBaseContext.Provider>;
+}
+
+export function useApiBase() {
+        return useContext(ApiBaseContext);
+}
+
 export function useFetchClient() {
-	return useMemo(() => createFetchClient<paths>({
-		baseUrl: "https://api.zemn.me",
-	})
-	, []);
+        const baseUrl = useApiBase();
+        return useMemo(() => createFetchClient<paths>({
+                baseUrl,
+        })
+        , [baseUrl]);
 }
 
 export function useZemnMeApi() {

--- a/project/zemn.me/testing/BUILD.bazel
+++ b/project/zemn.me/testing/BUILD.bazel
@@ -13,10 +13,8 @@ ts_project(
         "//:node_modules/@types/jest",
         "//:node_modules/@types/node",
         "//:node_modules/@types/selenium-webdriver",
-        "//:node_modules/@types/serve-handler",
         "//:node_modules/fast-glob",
         "//:node_modules/selenium-webdriver",
-        "//:node_modules/serve-handler",
         "//ts/selenium",
     ],
 )
@@ -41,6 +39,7 @@ jest_test(
     srcs = ["browser_test.js"],
     data = [
         ":ts",
+        "//project/zemn.me:start",
         "//project/zemn.me/api/cmd/localserver",
     ],
 )

--- a/project/zemn.me/testing/BUILD.bazel
+++ b/project/zemn.me/testing/BUILD.bazel
@@ -20,6 +20,20 @@ ts_project(
 )
 
 ts_project(
+    name = "admin_browser_ts",
+    srcs = ["browser_admin_test.ts"],
+    deps = [
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/@jest/globals",
+        "//:node_modules/@types/jest",
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/selenium-webdriver",
+        "//:node_modules/selenium-webdriver",
+        "//ts/selenium",
+    ],
+)
+
+ts_project(
     name = "admin_ts",
     srcs = ["admin_panel_test.tsx"],
     deps = [
@@ -39,6 +53,17 @@ jest_test(
     srcs = ["browser_test.js"],
     data = [
         ":ts",
+        "//project/zemn.me:start",
+        "//project/zemn.me/api/cmd/localserver",
+    ],
+)
+
+jest_test(
+    name = "admin_browser_test",
+    size = "medium",
+    srcs = ["browser_admin_test.js"],
+    data = [
+        ":admin_browser_ts",
         "//project/zemn.me:start",
         "//project/zemn.me/api/cmd/localserver",
     ],

--- a/project/zemn.me/testing/BUILD.bazel
+++ b/project/zemn.me/testing/BUILD.bazel
@@ -21,6 +21,20 @@ ts_project(
     ],
 )
 
+ts_project(
+    name = "admin_ts",
+    srcs = ["admin_panel_test.tsx"],
+    deps = [
+        "//:node_modules/@jest/globals",
+        "//:node_modules/@testing-library/react",
+        "//:node_modules/@types/jest",
+        "//:node_modules/@types/react",
+        "//:node_modules/@types/react-dom",
+        "//project/zemn.me/app",
+        "//project/zemn.me/app/admin",
+    ],
+)
+
 jest_test(
     name = "testing",
     size = "medium",
@@ -29,6 +43,16 @@ jest_test(
         ":ts",
         "//project/zemn.me/api/cmd/localserver",
     ],
+)
+
+jest_test(
+    name = "admin_panel_test",
+    srcs = ["admin_panel_test.js"],
+    env = {
+        "NEXT_PUBLIC_ZEMN_ME_API_BASE": "https://api.example.test",
+    },
+    jsdom = True,
+    deps = [":admin_ts"],
 )
 
 bazel_lint(

--- a/project/zemn.me/testing/admin_panel_test.tsx
+++ b/project/zemn.me/testing/admin_panel_test.tsx
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import Admin from '#root/project/zemn.me/app/admin/client.js';
+import { Providers } from '#root/project/zemn.me/app/providers.js';
+
+const token = 'eyJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMjM0NSIsImF1ZCI6ImNsaWVudCIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjowfQ.';
+
+const defaultSettings = { authorizers: [], fallbackPhone: '', entryCodes: [], partyMode: false };
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem('1', JSON.stringify({
+    'https://accounts.google.com': { id_token: token },
+  }));
+
+  global.fetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const method = init?.method ?? 'GET';
+    if (url.endsWith('/callbox/settings') && method === 'GET') {
+      return Promise.resolve(new Response(JSON.stringify(defaultSettings), { status: 200 }));
+    }
+    if (url.endsWith('/callbox/settings') && method === 'POST') {
+      return Promise.resolve(new Response(init?.body as BodyInit));
+    }
+    if (url.endsWith('/phone/number')) {
+      return Promise.resolve(new Response(JSON.stringify({ phoneNumber: '+1' }), { status: 200 }));
+    }
+    if (url.endsWith('/admin/uid')) {
+      return Promise.resolve(new Response('12345', { status: 200 }));
+    }
+    return Promise.reject(new Error(`Unhandled request: ${method} ${url}`));
+  }) as jest.Mock;
+});
+
+describe('zemn.me admin panel', () => {
+  it('adds and removes entry codes', async () => {
+    render(<Providers apiBaseUrl="https://api.example.test"><Admin /></Providers>);
+    const entryCodesLegend = await screen.findByText('Entry Codes');
+    const fieldset = entryCodesLegend.closest('fieldset')!;
+    const addBtn = within(fieldset).getByText('+');
+
+    expect(within(fieldset).queryAllByRole('textbox')).toHaveLength(0);
+    fireEvent.click(addBtn);
+    expect(within(fieldset).getAllByRole('textbox')).toHaveLength(1);
+
+    const removeBtn = within(fieldset).getByText('-');
+    fireEvent.click(removeBtn);
+    expect(within(fieldset).queryAllByRole('textbox')).toHaveLength(0);
+  });
+});

--- a/project/zemn.me/testing/browser_admin_test.ts
+++ b/project/zemn.me/testing/browser_admin_test.ts
@@ -1,0 +1,85 @@
+import { ChildProcess, spawn } from 'node:child_process';
+import { runfiles } from '@bazel/runfiles';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { Browser, By, ThenableWebDriver } from 'selenium-webdriver';
+
+import { Driver } from '#root/ts/selenium/webdriver.js';
+
+const token = 'eyJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMjM0NSIsImF1ZCI6ImNsaWVudCIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjowfQ.';
+
+describe('zemn.me admin panel (browser)', () => {
+  let apiProc: ChildProcess;
+  let apiOrigin: string;
+  let webProc: ChildProcess;
+  let origin: string;
+  let driver: ThenableWebDriver;
+
+  beforeAll(async () => {
+    const apiBin = runfiles.resolveWorkspaceRelative(
+      'project/zemn.me/api/cmd/localserver/localserver_/localserver',
+    );
+    apiProc = spawn(apiBin, { stdio: ['ignore', 'pipe', 'inherit'] });
+    apiOrigin = await new Promise<string>((resolve, reject) => {
+      apiProc.stdout!.on('data', chunk => {
+        const m = /PORT=(\d+)/.exec(chunk.toString());
+        if (m) {
+          resolve(`http://localhost:${m[1]}`);
+        }
+      });
+      apiProc.once('error', reject);
+      setTimeout(() => reject(new Error('api server did not start')), 10000);
+    });
+
+    const nextBin = runfiles.resolveWorkspaceRelative('project/zemn.me/start');
+    webProc = spawn(nextBin, {
+      stdio: ['ignore', 'pipe', 'inherit'],
+      env: { ...process.env, PORT: '0', NEXT_PUBLIC_ZEMN_ME_API_BASE: apiOrigin },
+    });
+    origin = await new Promise<string>((resolve, reject) => {
+      webProc.stdout!.on('data', chunk => {
+        const m = /localhost:(\d+)/.exec(chunk.toString());
+        if (m) {
+          resolve(`http://localhost:${m[1]}`);
+        }
+      });
+      webProc.once('error', reject);
+      setTimeout(() => reject(new Error('next server did not start')), 20000);
+    });
+  });
+
+  beforeEach(() => {
+    driver = Driver().forBrowser(Browser.CHROME).build();
+  });
+
+  afterAll(() => {
+    apiProc.kill();
+    webProc.kill();
+  });
+
+  it('adds and removes entry codes', async () => {
+    await driver.manage().setTimeouts({ implicit: 5000 });
+    await driver.get(`${origin}/admin`);
+    await driver.executeScript(
+      `localStorage.clear(); localStorage.setItem('1', JSON.stringify({ 'https://accounts.google.com': { id_token: '${token}' } }));`,
+    );
+    await driver.navigate().refresh();
+
+    const fieldset = await driver.findElement(By.xpath("//legend[text()='Entry Codes']/.."));
+    const addBtn = await fieldset.findElement(By.xpath(".//button[text()='+']"));
+
+    let inputs = await fieldset.findElements(By.css('fieldset input'));
+    expect(inputs.length).toBe(0);
+    await addBtn.click();
+    await driver.wait(async () => {
+      inputs = await fieldset.findElements(By.css('fieldset input'));
+      return inputs.length === 1;
+    }, 5000);
+
+    const removeBtn = await fieldset.findElement(By.xpath(".//button[text()='-']"));
+    await removeBtn.click();
+    await driver.wait(async () => {
+      inputs = await fieldset.findElements(By.css('fieldset input'));
+      return inputs.length === 0;
+    }, 5000);
+  });
+});

--- a/ts/next.js/next.config.ts
+++ b/ts/next.js/next.config.ts
@@ -15,6 +15,10 @@ export const eslint = {
 
 export const output = 'export';
 
+export const env = {
+        NEXT_PUBLIC_ZEMN_ME_API_BASE: process.env.NEXT_PUBLIC_ZEMN_ME_API_BASE,
+};
+
 
 export const generateBuildId = async () => { /*REPLACE*/ throw new Error() /*REPLACE*/ };
 

--- a/ts/next.js/rules.bzl
+++ b/ts/next.js/rules.bzl
@@ -70,6 +70,13 @@ def next_project(name, srcs, **kwargs):
         args = ["dev", native.package_name()],
     )
 
+    bin.next_binary(
+        name = "start",
+        data = [":build"] + srcs,
+        args = ["start", native.package_name()],
+        tags = ["generated"],
+    )
+
     bin.next(
         out_dirs = ["out"],
         name = "out",


### PR DESCRIPTION
## Summary
- add `start` binary to next.js rule with a generated tag
- run gazelle

## Testing
- `bazel run //:gazelle`
- `bazel test //ts/next.js/...` *(failed: build interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68684afbe874832c96f3657a9fac9481