### PR TITLE
Add night-time welcome salutation

### DIFF
--- a/project/zemn.me/api/server/BUILD.bazel
+++ b/project/zemn.me/api/server/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "grievances_test.go",
         "in_memory_ddb_test.go",
         "phone_features_test.go",
+        "salutation_test.go",
         "smoke_test.go",
     ],
     embed = [":server"],

--- a/project/zemn.me/api/server/salutation_test.go
+++ b/project/zemn.me/api/server/salutation_test.go
@@ -1,0 +1,21 @@
+package apiserver
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSalutationWelcome(t *testing.T) {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("failed to load location: %v", err)
+	}
+
+	s, err := Salutation(time.Date(2023, 1, 1, 22, 0, 0, 0, loc))
+	if err != nil {
+		t.Fatalf("Salutation returned error: %v", err)
+	}
+	if s != "Welcome. " {
+		t.Fatalf("expected 'Welcome. ', got %q", s)
+	}
+}


### PR DESCRIPTION
## Summary
- parametrize `Salutation` with a time argument instead of using a package variable
- update the server to pass `time.Now()` to `Salutation`
- adapt night welcome test

## Testing
- `bazel test //project/zemn.me/api/server:server_test --test_output=errors`


------
https://chatgpt.com/codex/tasks/task_e_68737f086758832c942b179db85a1a0b