### PR TITLE
Proxy OIDC well-known paths to API

### DIFF
--- a/ts/pulumi/zemn.me/index.ts
+++ b/ts/pulumi/zemn.me/index.ts
@@ -53,15 +53,16 @@ export class Component extends Pulumi.ComponentResource {
 				directory: 'project/zemn.me/out',
 				zoneId: args.zoneId,
 				domain: args.domain,
-				noIndex: args.noIndex,
-				email: false,
-				otherTXTRecords: [
-					"google-site-verification=Eocoh5nOKEaypNal4oA8OInUzoY9aTTsulvv8aG7Aag"
-				],
-				tags,
-			},
-			{ parent: this }
-		);
+                                noIndex: args.noIndex,
+                                email: false,
+                                otherTXTRecords: [
+                                        "google-site-verification=Eocoh5nOKEaypNal4oA8OInUzoY9aTTsulvv8aG7Aag"
+                                ],
+                                tags,
+                                wellKnownOidcDomain: ['api', args.domain].join('.'),
+                        },
+                        { parent: this }
+                );
 
 		const availability = new Website(
 			`${name}_availability_zemn_me_website`,


### PR DESCRIPTION
## Summary
- expose optional origin for OIDC .well-known endpoints in generic website CloudFront config
- route zemn.me `.well-known/openid-configuration` and `.well-known/jwks.json` via api.zemn.me

## Testing
- `bazel test //ts/pulumi/lib/website:website //ts/pulumi:tests` *(fails: certificate_unknown PKIX path building failed)*
- `gazelle` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e18e69644832ca02d3e67e4e5fae0