### PR TITLE
test: add prettier format test to ts_project

### DIFF
--- a/bzl/format/BUILD.bazel
+++ b/bzl/format/BUILD.bazel
@@ -1,4 +1,12 @@
+load("@npm//:prettier/package_json.bzl", prettier_bin = "bin")
 load("//bzl:rules.bzl", "bazel_lint")
+
+package(default_visibility = ["//:__subpackages__"])
+
+prettier_bin.prettier_binary(
+    name = "prettier",
+    visibility = ["//visibility:public"],
+)
 
 #load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 #load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")

--- a/ts/rules.bzl
+++ b/ts/rules.bzl
@@ -3,6 +3,7 @@ load("@aspect_rules_ts//ts:defs.bzl", _ts_config = "ts_config", _ts_project = "t
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//bzl/lint:linters.bzl", "eslint_test")
+load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("//js:rules.bzl", _js_binary = "js_binary")
 load("//js/jest:rules.bzl", _jest_test = "jest_test")
 
@@ -45,6 +46,14 @@ def ts_lint(name, **kwargs):
     eslint_test(
         name = name,
         **kwargs
+    )
+
+def prettier_test(name, srcs = [], tags = []):
+    format_test(
+        name = name,
+        srcs = srcs + ["//:.prettierrc.json"],
+        javascript = "//bzl/format:prettier",
+        tags = tags,
     )
 
 def ts_project(name, visibility = None, lint = True, deps = [], data = [], resolve_json_module = True, srcs = None, tsconfig = "//:tsconfig", preserve_jsx = None, tags = [], **kwargs):
@@ -103,3 +112,5 @@ def ts_project(name, visibility = None, lint = True, deps = [], data = [], resol
 
     if lint:
         ts_lint(name = name + "_lint", srcs = [name + "_typings"], tags = tags)
+
+    prettier_test(name = name + "_prettier", srcs = srcs, tags = tags)

--- a/ts/rules.bzl
+++ b/ts/rules.bzl
@@ -1,9 +1,9 @@
+load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 load("@aspect_rules_ts//ts:defs.bzl", _ts_config = "ts_config", _ts_project = "ts_project")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//bzl/lint:linters.bzl", "eslint_test")
-load("@aspect_rules_lint//format:defs.bzl", "format_test")
 load("//js:rules.bzl", _js_binary = "js_binary")
 load("//js/jest:rules.bzl", _jest_test = "jest_test")
 

--- a/ts/rules.bzl
+++ b/ts/rules.bzl
@@ -60,8 +60,8 @@ def ts_project(name, visibility = None, lint = True, deps = [], data = [], resol
     """
     Compile a set of typescript files, dependencies, runtime data and other source files into typescript types and source maps.
 
-    Also generates an _typings tag (typescript types) and an _lint tag
-    (lint tests).
+    Also generates _typings (TypeScript types), _lint (eslint checks), and
+    _prettier (format checks) tags.
 
     Note that there isn't a way to exempt specific files from aspect_rules_lint as I can see,
     so deps which are invalid eslint files should instead use an /* eslint-disable */ comment.


### PR DESCRIPTION
## Summary
- expose prettier binary for formatting
- run prettier format_test for each ts_project

## Testing
- `bazel run //:gazelle` *(fails: certificate_unknown)*
- `bazel test //ts/...` *(fails: certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_689e1a6e2078832c9ce22c0f7e79343f