### PR TITLE
Use run_lazily for buildifier in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -114,5 +114,5 @@
 	"typescript.preferences.autoImportFileExcludePatterns": [
 		"**/_*"
 	],
-	"bazel.buildifierExecutable": "@@//:buildifier"
+        "bazel.buildifierExecutable": "${workspaceFolder}/sh/bin/buildifier"
 }

--- a/sh/bin/buildifier
+++ b/sh/bin/buildifier
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-"$(dirname ${BASH_SOURCE[0]})/../run_bazel.sh" //sh/bin:buildifier "${@}"
+"$(dirname ${BASH_SOURCE[0]})/run_lazily.sh" //sh/bin:buildifier "${@}"


### PR DESCRIPTION
## Summary
- Ensure VS Code runs buildifier through the `run_lazily` wrapper
- Wrap `sh/bin/buildifier` with `run_lazily.sh` instead of `run_bazel.sh`

## Testing
- `$(pwd)/sh/bin/gazelle` *(fails: certificate_unknown)*
- `bazel test //sh/bin:all` *(fails: certificate_unknown)*
- `bazel test //.vscode:all` *(fails: certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_689e2240a6f0832c951156cad7c43333