### PR TITLE
fix: correct KMS env variable check

### DIFF
--- a/project/zemn.me/api/server/server.go
+++ b/project/zemn.me/api/server/server.go
@@ -136,11 +136,11 @@ func NewServer(ctx context.Context, opts NewServerOptions) (*Server, error) {
 }
 
 func provisionSigningKey() (k jose.JSONWebKey, err error) {
-	if os.Getenv("OIDC_JWT_JMS_KEY") != "" {
-		return provisionKMSSigningKey()
-	}
+        if os.Getenv("OIDC_JWT_KMS_KEY_ID") != "" {
+                return provisionKMSSigningKey()
+        }
 
-	return provisionTestingSigningKey()
+        return provisionTestingSigningKey()
 }
 
 func provisionTestingSigningKey() (k jose.JSONWebKey, err error) {


### PR DESCRIPTION
## Summary
- use OIDC_JWT_KMS_KEY_ID env var to decide whether to provision KMS signing key

## Testing
- `bazel run //:gazelle` *(fails: certificate_unknown for bcr.bazel.build)*
- `bazel test //project/zemn.me/api/server:server_test` *(fails: certificate_unknown for bcr.bazel.build)*

------
https://chatgpt.com/codex/tasks/task_e_68a75baa1b6c832c993f093a0ba7967e