### PR TITLE
refactor lens to church encoding

### DIFF
--- a/ts/lens.ts
+++ b/ts/lens.ts
@@ -1,16 +1,16 @@
-export type Lens<S, A> = [
-	get: (s: S) => A,
-	set: (v: A, s: S) => S
-];
-
-
+export type Lens<S, A> = <R>(
+        f: (
+                get: (s: S) => A,
+                set: (v: A, s: S) => S,
+        ) => R,
+) => R;
 
 export function LensGet<S, A>(lens: Lens<S, A>) {
-	return lens[0]
+        return lens((get) => get);
 }
 
 export function LensSet<S, A>(lens: Lens<S, A>) {
-	return lens[1]
+        return lens((_, set) => set);
 }
 
 /**
@@ -18,25 +18,28 @@ export function LensSet<S, A>(lens: Lens<S, A>) {
  * be used where a promise would be.
  */
 export function lensPromise<S, A>(lens: Lens<S, A>): Lens<Promise<S>, Promise<A>> {
-	return [
-		/** get */ async s => Promise.resolve(LensGet(lens)(await s)),
-		/** set */ async (a, b) => LensSet(lens)(await a, await b)
-	]
+        return (f) =>
+                lens((get, set) =>
+                        f(
+                                /** get */ async s => Promise.resolve(get(await s)),
+                                /** set */ async (a, b) => Promise.resolve(set(await a, await b)),
+                        ),
+                );
 }
 
-
-
 export function pipeLens<A, B, C>(
-	lensAB: Lens<A, B>,
-	lensBC: Lens<B, C>
+        lensAB: Lens<A, B>,
+        lensBC: Lens<B, C>,
 ): Lens<A, C> {
-	return [
-		// get: A => C
-		(a: A) => LensGet(lensBC)(LensGet(lensAB)(a)),
-		// set: (C, A) => A
-		(c: C, a: A) => LensSet(lensAB)(
-			LensSet(lensBC)(c, LensGet(lensAB)(a)),
-			a
-		)
-	];
+        return (f) =>
+                lensAB((getAB, setAB) =>
+                        lensBC((getBC, setBC) =>
+                                f(
+                                        // get: A => C
+                                        (a: A) => getBC(getAB(a)),
+                                        // set: (C, A) => A
+                                        (c: C, a: A) => setAB(setBC(c, getAB(a)), a),
+                                ),
+                        ),
+                );
 }

--- a/ts/lens.ts
+++ b/ts/lens.ts
@@ -6,7 +6,7 @@ export type Lens<S, A> = <R>(
 ) => R;
 
 export function LensGet<S, A>(lens: Lens<S, A>) {
-        return lens((get) => get);
+        return lens(get => get);
 }
 
 export function LensSet<S, A>(lens: Lens<S, A>) {
@@ -18,7 +18,7 @@ export function LensSet<S, A>(lens: Lens<S, A>) {
  * be used where a promise would be.
  */
 export function lensPromise<S, A>(lens: Lens<S, A>): Lens<Promise<S>, Promise<A>> {
-        return (f) =>
+        return f =>
                 lens((get, set) =>
                         f(
                                 /** get */ async s => Promise.resolve(get(await s)),
@@ -31,7 +31,7 @@ export function pipeLens<A, B, C>(
         lensAB: Lens<A, B>,
         lensBC: Lens<B, C>,
 ): Lens<A, C> {
-        return (f) =>
+        return f =>
                 lensAB((getAB, setAB) =>
                         lensBC((getBC, setBC) =>
                                 f(

--- a/ts/serde/serde.ts
+++ b/ts/serde/serde.ts
@@ -128,7 +128,7 @@ export function serdeLens<Haystack, Needle, Deserialized>(
         lens: Lens<Haystack, Needle>,
         serde: Serde<Deserialized, Needle>,
 ): Lens<Haystack, Deserialized> {
-        return (f) => f(
+        return f => f(
                 v => Deserialize(serde)(LensGet(lens)(v)),
                 (needle, haystack) => LensSet(lens)(Serialize(serde)(needle), haystack),
         )

--- a/ts/serde/serde.ts
+++ b/ts/serde/serde.ts
@@ -125,12 +125,12 @@ export const serdeb64ByteString: Serde<Uint8Array, string> = [
  * provided mapping two and from {@link Needle} and {@link Deserialized}.
  */
 export function serdeLens<Haystack, Needle, Deserialized>(
-	lens: Lens<Haystack, Needle>,
-	serde: Serde<Deserialized, Needle>,
+        lens: Lens<Haystack, Needle>,
+        serde: Serde<Deserialized, Needle>,
 ): Lens<Haystack, Deserialized> {
-	return [
-		v => Deserialize(serde)(LensGet(lens)(v)),
-		(needle, haystack) => LensSet(lens)(Serialize(serde)(needle), haystack)
-	]
+        return (f) => f(
+                v => Deserialize(serde)(LensGet(lens)(v)),
+                (needle, haystack) => LensSet(lens)(Serialize(serde)(needle), haystack),
+        )
 }
 

--- a/ts/storage/storage.ts
+++ b/ts/storage/storage.ts
@@ -2,7 +2,7 @@ import { Lens, LensGet } from "#root/ts/lens.js";
 import { None, Option, Some, unwrap } from "#root/ts/option/types.js";
 
 export function asyncStorageLens(k: string): Lens<Promise<Storage>, Promise<string | null>> {
-        return (f) => f(
+        return f => f(
                 /** get */async v => (await v).getItem(k),
                 /** set */async (pv, storage) => {
                         const v = await pv;
@@ -57,7 +57,7 @@ export async function asyncStorageLensKey<T>(l: Lens<Promise<Storage>, Promise<T
 }
 
 export function StorageLens(k: string): Lens<Storage, string | null> {
-        return (f) => f(
+        return f => f(
                 /** get */ v => v.getItem(k),
                 /** set */ (v, storage) => {
                         if (v === null) {

--- a/ts/storage/storage.ts
+++ b/ts/storage/storage.ts
@@ -2,18 +2,18 @@ import { Lens, LensGet } from "#root/ts/lens.js";
 import { None, Option, Some, unwrap } from "#root/ts/option/types.js";
 
 export function asyncStorageLens(k: string): Lens<Promise<Storage>, Promise<string | null>> {
-	return [
-		/** get */async v => (await v).getItem(k),
-		/** set */async (pv, storage) => {
-			const v = await pv;
-			if (v === null) {
-				(await storage).removeItem(k)
-			} else {
-				(await storage).setItem(k, v);
-			}
-			return storage
-		},
-	]
+        return (f) => f(
+                /** get */async v => (await v).getItem(k),
+                /** set */async (pv, storage) => {
+                        const v = await pv;
+                        if (v === null) {
+                                (await storage).removeItem(k)
+                        } else {
+                                (await storage).setItem(k, v);
+                        }
+                        return storage
+                },
+        )
 }
 
 /**
@@ -57,16 +57,16 @@ export async function asyncStorageLensKey<T>(l: Lens<Promise<Storage>, Promise<T
 }
 
 export function StorageLens(k: string): Lens<Storage, string | null> {
-	return [
-		/** get */ v => v.getItem(k),
-		/** set */ (v, storage) => {
-			if (v === null) {
-				storage.removeItem(k)
-			} else {
-				storage.setItem(k, v);
-			}
-			return storage
-		},
-	]
+        return (f) => f(
+                /** get */ v => v.getItem(k),
+                /** set */ (v, storage) => {
+                        if (v === null) {
+                                storage.removeItem(k)
+                        } else {
+                                storage.setItem(k, v);
+                        }
+                        return storage
+                },
+        )
 }
 


### PR DESCRIPTION
## Summary
- refactor lenses to use Church-encoded representation
- adjust storage and serde helpers for new lens form

## Testing
- `bazel run //:gazelle` *(fails: certificate_unknown PKIX path building failed)*
- `bazel test $(pwd)/ts/...` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1b773ce4832ca27883327526c07d