### PR TITLE
chore(ts/result): annotate pure functions

### DIFF
--- a/ts/result.ts
+++ b/ts/result.ts
@@ -148,7 +148,7 @@ export class impl<T> extends NewType<T> {
  * @deprecated please use {@link r}
  * Returns a {@link Result} that represents a success.
  */
-export function Ok<T>(v: T): Ok<T> {
+/*#__NO_SIDE_EFFECTS__*/ export function Ok<T>(v: T): Ok<T> {
 	return new impl(types.Ok(v))
 }
 
@@ -175,7 +175,7 @@ export type Result<T, E = Error> = impl<types.Result<T, E>>
  * Returns a {@link Result} that is in error
  * with the given error.
  */
-export function Err<T>(v: T): Err<T> {
+/*#__NO_SIDE_EFFECTS__*/ export function Err<T>(v: T): Err<T> {
 	return new impl(types.Err(v))
 }
 

--- a/ts/result/openapi-fetch/fetchResult.ts
+++ b/ts/result/openapi-fetch/fetchResult.ts
@@ -5,20 +5,28 @@ import { Err, Ok, Result } from "#root/ts/result/result.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type FailureResponse<T extends Record<string | number, any>> =
-	ErrorResponse<ResponseObjectMap<T>>;
+        ErrorResponse<ResponseObjectMap<T>>;
 
 /**
  * Turns a response from openapi-fetch into a {@link Result}.
  */
-export function fetchResult<Z, A extends Record<string | number, Z>, B, C extends `${string}/${string}`, E>(
-	r: FetchResponse<A, B, C>,
-	err: (v: FailureResponse<A>) => E
+/*#__NO_SIDE_EFFECTS__*/ export function fetchResult<
+        Z,
+        A extends Record<string | number, Z>,
+        B,
+        C extends `${string}/${string}`,
+        E
+>(
+        r: FetchResponse<A, B, C>,
+        err: (v: FailureResponse<A>) => E
 ): Result<
-		ParseAsResponse<SuccessResponse<ResponseObjectMap<A>, C>, B>
-	, E> {
-	if (r.error !== undefined)
-		return Err(err(r.error));
+        ParseAsResponse<SuccessResponse<ResponseObjectMap<A>, C>, B>,
+        E
+> {
+        if (r.error !== undefined)
+                return Err(err(r.error));
 
-	// i cant see how this would be undefined
-	return Ok(r.data!)
+        // i cant see how this would be undefined
+        return Ok(r.data!)
 }
+

--- a/ts/result/react-query/queryResult.ts
+++ b/ts/result/react-query/queryResult.ts
@@ -7,7 +7,7 @@ import { Err, Ok, Result } from "#root/ts/result/result.js";
  * Returns {@link None} if the query is still loading. Returns
  * {@link Some}({@Link Result}) if done loading.
  */
-export function queryResult<T, E>(
+/*#__NO_SIDE_EFFECTS__*/ export function queryResult<T, E>(
 	r: UseQueryResult<T, E>
 ): Option<Result<T, E>> {
 	switch (r.status) {

--- a/ts/result/result.ts
+++ b/ts/result/result.ts
@@ -11,44 +11,44 @@ import {
 export type Result<T, E> = Either<E, T>
 
 /** Constructors */
-export const Ok = <T, E = never>(v: T): Result<T, E> => Right<T, E>(v)
-export const Err = <E, T = never>(e: E): Result<T, E> => Left<E, T>(e)
+export const Ok = /*#__NO_SIDE_EFFECTS__*/ <T, E = never>(v: T): Result<T, E> => Right<T, E>(v)
+export const Err = /*#__NO_SIDE_EFFECTS__*/ <E, T = never>(e: E): Result<T, E> => Left<E, T>(e)
 
 /** Compatibility aliases (types) — corrected */
 export type Ok<T> = Result<T, never>
 export type Err<E> = Result<never, E>
 
 /** Predicates */
-export const is_ok = <T, E>(v: Result<T, E>) => is_right(v)
-export const is_err = <T, E>(v: Result<T, E>) => is_left(v)
+export const is_ok = /*#__NO_SIDE_EFFECTS__*/ <T, E>(v: Result<T, E>) => is_right(v)
+export const is_err = /*#__NO_SIDE_EFFECTS__*/ <T, E>(v: Result<T, E>) => is_left(v)
 
 /** Left value or throw if Ok */
-export function unwrap_err<T, E>(v: Result<T, E>): E {
+/*#__NO_SIDE_EFFECTS__*/ export function unwrap_err<T, E>(v: Result<T, E>): E {
 	return either<E, T, E>(v, e => e, () => { throw new Error("Not in error.") })
 }
 
 /** Right value or throw the error */
-export function unwrap<T, E>(v: Result<T, E>): T {
+/*#__NO_SIDE_EFFECTS__*/ export function unwrap<T, E>(v: Result<T, E>): T {
 	return either<E, T, T>(v, e => { throw e as unknown }, t => t)
 }
 
 /** Assume Ok (will throw if actually Err) */
-export function unwrap_unsafe<T>(v: Ok<T>): T {
+/*#__NO_SIDE_EFFECTS__*/ export function unwrap_unsafe<T>(v: Ok<T>): T {
 	return unwrap(v)
 }
-export const unwrap_unchecked = unwrap_unsafe
+export const unwrap_unchecked = /*#__NO_SIDE_EFFECTS__*/ unwrap_unsafe
 
 // this used to actually not check but now i am not sure that is even poss
-export const unwrap_err_unchecked = unwrap_err
+export const unwrap_err_unchecked = /*#__NO_SIDE_EFFECTS__*/ unwrap_err
 
 
 /** Right value or fallback */
-export function unwrap_or<T, TT>(v: Result<T, unknown>, fallback: TT): T | TT {
+/*#__NO_SIDE_EFFECTS__*/ export function unwrap_or<T, TT>(v: Result<T, unknown>, fallback: TT): T | TT {
 	return either<unknown, T, T | TT>(v, () => fallback, t => t)
 }
 
 /** If Err, map error to a new Result; else pass through */
-export function or_else<S, F, NF>(
+/*#__NO_SIDE_EFFECTS__*/ export function or_else<S, F, NF>(
 	v: Result<S, F>,
 	fallback: (e: F) => Result<S, NF>
 ): Result<S, NF> {
@@ -56,7 +56,7 @@ export function or_else<S, F, NF>(
 }
 
 /** If Err, compute default; else value */
-export function unwrap_or_else<T1, T2, E>(
+/*#__NO_SIDE_EFFECTS__*/ export function unwrap_or_else<T1, T2, E>(
 	v: Result<T1, E>,
 	fallback: (e: E) => T2
 ): T1 | T2 {
@@ -64,7 +64,7 @@ export function unwrap_or_else<T1, T2, E>(
 }
 
 /** Chain on Ok; keep Err */
-export function and_then<T, E, O>(
+/*#__NO_SIDE_EFFECTS__*/ export function and_then<T, E, O>(
 	v: Result<T, E>,
 	f: (value: T) => O
 ): Result<O, E> {
@@ -72,7 +72,7 @@ export function and_then<T, E, O>(
 }
 
 /** Flatten Result<Result<T,E2>,E1> → Result<T, E1|E2> */
-export function flatten<T, E1, E2>(
+/*#__NO_SIDE_EFFECTS__*/ export function flatten<T, E1, E2>(
 	v: Result<Result<T, E2>, E1>
 ): Result<T, E1 | E2> {
 	return either<E1, Result<T, E2>, Result<T, E1 | E2>>(
@@ -83,7 +83,7 @@ export function flatten<T, E1, E2>(
 }
 
 /** Zip two Results (first Err wins) */
-export function zip<T, TT, E>(
+/*#__NO_SIDE_EFFECTS__*/ export function zip<T, TT, E>(
 	a: Result<T, E>,
 	b: Result<TT, E>
 ): Result<[T, TT], E> {
@@ -99,7 +99,7 @@ export function zip<T, TT, E>(
 }
 
 /** Result<Promise<T>,E> → Promise<Result<T,E>> */
-export async function result_promise_transpose<T, E>(
+/*#__NO_SIDE_EFFECTS__*/ export async function result_promise_transpose<T, E>(
 	r: Result<Promise<T>, E>
 ): Promise<Result<T, E>> {
 	return either<E, Promise<T>, Promise<Result<T, E>>>(
@@ -110,7 +110,7 @@ export async function result_promise_transpose<T, E>(
 }
 
 /** Collect array of Results; stop at first Err */
-export function result_collect<T, E>(arr: Result<T, E>[]): Result<T[], E> {
+/*#__NO_SIDE_EFFECTS__*/ export function result_collect<T, E>(arr: Result<T, E>[]): Result<T[], E> {
 	const out: T[] = []
 	for (const res of arr) {
 		const next = either<E, T, Result<null, E>>(
@@ -124,7 +124,7 @@ export function result_collect<T, E>(arr: Result<T, E>[]): Result<T[], E> {
 }
 
 /** If Ok, replace value with vv; else keep Err */
-export function result_and<V, E>(
+/*#__NO_SIDE_EFFECTS__*/ export function result_and<V, E>(
 	v: Result<unknown, E>,
 	vv: V
 ): Result<V, E> {


### PR DESCRIPTION
## Summary
- mark Result helpers as `/*#__NO_SIDE_EFFECTS__*/`

## Testing
- `gazelle $(pwd)/ts/result` *(fails: certificate_unknown)*
- `bazel test $(pwd)/ts/result/...` *(fails: certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68c465113004832c9089aa87f25ab037