### PR TITLE
annotate option functions with no side effects

### DIFF
--- a/ts/option/option.ts
+++ b/ts/option/option.ts
@@ -9,30 +9,35 @@ class impl<T> extends NewType<T> {
 	/**
 	 * True if this {@link Option} represents {@link None}.
 	 */
-	is_none<T>(this: Option<T>): this is None { return types.is_none(this.value) }
+        /*#__NO_SIDE_EFFECTS__*/
+        is_none<T>(this: Option<T>): this is None { return types.is_none(this.value) }
 
 	/**
 	 * True if this {@link Option} is {@link Some}thing.
 	 */
-	is_some<T>(this: Option<T>): this is Some<T> { return types.is_some(this.value) }
+        /*#__NO_SIDE_EFFECTS__*/
+        is_some<T>(this: Option<T>): this is Some<T> { return types.is_some(this.value) }
 
 	/**
 	 * If this {@link Option} is {@link Some}thing, return its value; otherwise
 	 * throw an error.
 	 */
-	unwrap<T>(this: Option<T>): T { return types.unwrap(this.value) }
+        /*#__NO_SIDE_EFFECTS__*/
+        unwrap<T>(this: Option<T>): T { return types.unwrap(this.value) }
 
 	/**
 	 * If this {@link Option} is {@link Some}thing, return its value; otherwise
 	 * return the {@link fallback} value.
 	 */
-	unwrap_or<T1, T2>(this: Option<T1>, fallback: T2): T1 | T2 { return types.unwrap_or(this.value, fallback) }
+        /*#__NO_SIDE_EFFECTS__*/
+        unwrap_or<T1, T2>(this: Option<T1>, fallback: T2): T1 | T2 { return types.unwrap_or(this.value, fallback) }
 
 	/**
 	 * If this {@link Option} is {@link Some}thing, return its value; otherwise
 	 * return the result of {@link fallback}().
 	 */
-	unwrap_or_else<T1, T2>(this: Option<T1>, fallback: () => T2): T1 | T2 {
+        /*#__NO_SIDE_EFFECTS__*/
+        unwrap_or_else<T1, T2>(this: Option<T1>, fallback: () => T2): T1 | T2 {
 		return types.unwrap_or_else(this.value, fallback)
 	}
 
@@ -40,7 +45,8 @@ class impl<T> extends NewType<T> {
 	 * If this {@link Option} is {@link Some}thing, perform given operation
 	 * {@link f} on it.
 	 */
-	and_then<T, O>(this: Option<T>, f: (v: T) => O): Option<O> {
+        /*#__NO_SIDE_EFFECTS__*/
+        and_then<T, O>(this: Option<T>, f: (v: T) => O): Option<O> {
 		return new impl(types.and_then(this.value, f));
 	}
 
@@ -48,7 +54,8 @@ class impl<T> extends NewType<T> {
 	 * If this {@link Option} has another Option nested directly in it,
 	 * un-nests the options to a single potential value.
 	 */
-	flatten<T>(this: Option<Option<T>>): Option<T> {
+        /*#__NO_SIDE_EFFECTS__*/
+        flatten<T>(this: Option<Option<T>>): Option<T> {
 		if (this.is_none()) return None;
 		return this.unwrap();
 	}
@@ -58,7 +65,8 @@ class impl<T> extends NewType<T> {
 	 * return a new option that is a tuple of both values
 	 * [{@link T}, {@link TT}], if both values are {@link Some}.
 	 */
-	zip<T, TT>(this: Option<T>, other: Option<TT>): Option<[T, TT]> {
+        /*#__NO_SIDE_EFFECTS__*/
+        zip<T, TT>(this: Option<T>, other: Option<TT>): Option<[T, TT]> {
 		return new impl(types.zip<T, TT>(this.value, other.value));
 	}
 
@@ -66,7 +74,8 @@ class impl<T> extends NewType<T> {
 	 * If this {@link Option} is {@link Some}thing, swap it out for
 	 * input value {@link v}.
 	 */
-	and<V>(this: Option<unknown>, v: V): Option<V> {
+        /*#__NO_SIDE_EFFECTS__*/
+        and<V>(this: Option<unknown>, v: V): Option<V> {
 		if (this.is_some()) return Some(v);
 
 		return None;
@@ -77,7 +86,8 @@ class impl<T> extends NewType<T> {
 	 * on success is our inner value {@link T}, or – upon failure –
 	 * the provided error value {@link err}.
 	 */
-	ok_or<T, E>(this: Option<T>, err: E): Result<T, E> {
+        /*#__NO_SIDE_EFFECTS__*/
+        ok_or<T, E>(this: Option<T>, err: E): Result<T, E> {
 		return new resultImpl(
 			types.ok_or<T, E>(this.value, err)
 		)
@@ -87,7 +97,8 @@ class impl<T> extends NewType<T> {
 	 * Convert a union of some value ({@link T}) or undefined
 	 * into {@link Some}({@link T}) or {@link None}.
 	 */
-	from<T>(this: Some<T | undefined>): Option<T> {
+        /*#__NO_SIDE_EFFECTS__*/
+        from<T>(this: Some<T | undefined>): Option<T> {
 		return new impl(
 			types.from<T>(this.unwrap())
 		)
@@ -98,7 +109,8 @@ class impl<T> extends NewType<T> {
 	 * on success is our inner value {@link T}, or – upon failure –
 	 * the result of calling provided error function {@link err}().
 	 */
-	ok_or_else<T, E>(this: Option<T>, err: () => E): Result<T, E> {
+        /*#__NO_SIDE_EFFECTS__*/
+        ok_or_else<T, E>(this: Option<T>, err: () => E): Result<T, E> {
 		return new resultImpl(
 			types.ok_or_else<T, E>(
 				this.value, err
@@ -111,7 +123,8 @@ class impl<T> extends NewType<T> {
 	 * value on success is {@link T} is converted into an
 	 * {@link Option}<{@link T}> by discarding the inner error, if any.
 	 */
-	absorb_result<T>(this: Option<Result<T, unknown>>): Option<T> {
+        /*#__NO_SIDE_EFFECTS__*/
+        absorb_result<T>(this: Option<Result<T, unknown>>): Option<T> {
 		if (this.is_none()) return this;
 
 		const inner = this.unwrap() ;
@@ -127,6 +140,7 @@ class impl<T> extends NewType<T> {
  * @deprecated please use {@link types} instead
  * An {@link Option} representing a value that exists.
  */
+/*#__NO_SIDE_EFFECTS__*/
 export function Some<T>(v: T): Some<T> {
 	return new impl(types.Some(v))
 }
@@ -154,4 +168,4 @@ export type Option<T> = impl<types.Option<T>>
  * @deprecated please use {@link types} instead
  * A value representing nothing.
  */
-export const None: None = new impl(types.None);
+export const None: None = /*#__NO_SIDE_EFFECTS__*/ new impl(types.None);

--- a/ts/option/types.ts
+++ b/ts/option/types.ts
@@ -16,59 +16,67 @@ import { and_then as result_and_then, Err, Ok, Result } from "#root/ts/result/re
  */
 export type Option<T> = Either<null, T>
 
-export const _None = <T = never>(): Option<T> => Left<null, T>(null)
+export const _None = /*#__NO_SIDE_EFFECTS__*/ <T = never>(): Option<T> => Left<null, T>(null)
 /** Construct None (no value). */
-export const None = _None();
+export const None = /*#__NO_SIDE_EFFECTS__*/ _None();
 
 export type Some<T> = Right<T, null>;
 export type None = typeof None; // Left<null>
 
 /** Construct Some(value). */
-export const Some = <T>(v: T): Option<T> => Right<T, null>(v)
+export const Some = /*#__NO_SIDE_EFFECTS__*/ <T>(v: T): Option<T> => Right<T, null>(v)
 
 /** True if it’s Some. */
-export const is_some = <T>(o: Option<T>) => is_right(o)
+export const is_some = /*#__NO_SIDE_EFFECTS__*/ <T>(o: Option<T>) => is_right(o)
 
 /** True if it’s None. */
-export const is_none = <T>(o: Option<T>) => is_left(o)
+export const is_none = /*#__NO_SIDE_EFFECTS__*/ <T>(o: Option<T>) => is_left(o)
 
 /** Get the value or throw if None. */
+/*#__NO_SIDE_EFFECTS__*/
 export function unwrap<T>(o: Option<T>): T {
   return either<null, T, T>(o, () => { throw new Error("Cannot unwrap Option; has no value.") }, v => v)
 }
 
 /** Get the value (assumes Some). */
+/*#__NO_SIDE_EFFECTS__*/
 export function unwrap_unchecked<T>(o: Option<T>): T {
   return either<null, T, T>(o, () => { throw new Error("unwrap_unchecked called on None") }, v => v)
 }
 
 /** Get the value or a fallback. */
+/*#__NO_SIDE_EFFECTS__*/
 export function unwrap_or<T, T2>(o: Option<T>, fallback: T2): T | T2 {
   return either<null, T, T | T2>(o, () => fallback, v => v)
 }
 
 /** Get the value or call a fallback. */
+/*#__NO_SIDE_EFFECTS__*/
 export function unwrap_or_else<T, T2>(o: Option<T>, fallback: () => T2): T | T2 {
   return either<null, T, T | T2>(o, () => fallback(), v => v)
 }
 
 /** If Some, apply `f` to the value; if None, keep None. */
+/*#__NO_SIDE_EFFECTS__*/
 export function and_then<T, O>(o: Option<T>, f: (v: T) => O): Option<O> {
   return either<null, T, Option<O>>(o, () => None, v => Some(f(v)))
 }
 
 /** Flatten Option<Option<T>> → Option<T>. */
+/*#__NO_SIDE_EFFECTS__*/
 export function flatten<T>(o: Option<Option<T>>): Option<T> {
   // FIXED: use eliminator so branches return Option<T>
   return either<null, Option<T>, Option<T>>(o, () => None, x => x)
 }
 
 /** If Some, run `f` which returns an Option; otherwise None. */
+/*#__NO_SIDE_EFFECTS__*/
 export function and_then_flatten<T, O>(o: Option<T>, f: (v: T) => Option<O>): Option<O> {
   return either<null, T, Option<O>>(o, () => None, v => f(v))
 }
 
 /** Zip two Options. If both Some, returns Some([a,b]); otherwise None. */
+/*#__NO_SIDE_EFFECTS__*/
 export function zip<T, TT>(a: Option<T>, b: Option<TT>): Option<[T, TT]> {
   return either<null, T, Option<[T, TT]>>(a,
     () => None,
@@ -80,21 +88,25 @@ export function zip<T, TT>(a: Option<T>, b: Option<TT>): Option<[T, TT]> {
 }
 
 /** If this Option is Some, replace it with `v`; else keep None. */
+/*#__NO_SIDE_EFFECTS__*/
 export function and<V>(self: Option<unknown>, v: V): Option<V> {
   return is_some(self) ? Some(v) : None
 }
 
 /** Convert Option<T> → Result<T, E> using a provided error for None. */
+/*#__NO_SIDE_EFFECTS__*/
 export function ok_or<T, E>(self: Option<T>, err: E): Result<T, E> {
   return either<null, T, Result<T, E>>(self, () => Err<E, T>(err), v => Ok<T, E>(v))
 }
 
 /** Convert Option<T> → Result<T, E> using a thunk for the error. */
+/*#__NO_SIDE_EFFECTS__*/
 export function ok_or_else<T, E>(self: Option<T>, err: () => E): Result<T, E> {
   return either<null, T, Result<T, E>>(self, () => Err<E, T>(err()), v => Ok<T, E>(v))
 }
 
 /** From possibly-undefined: defined → Some(x), undefined → None. */
+/*#__NO_SIDE_EFFECTS__*/
 export function from<T>(v: T | undefined): Option<T> {
   return isDefined(v) ? Some(v) : None
 }
@@ -103,6 +115,7 @@ export function from<T>(v: T | undefined): Option<T> {
  * Map Option<Result<T,E>> by applying `f` to the Ok value when present.
  * None stays None; Err stays Err.
  */
+/*#__NO_SIDE_EFFECTS__*/
 export function option_result_and_then<T, O, E>(
   o: Option<Result<T, E>>,
   f: (v: T) => O
@@ -116,6 +129,7 @@ export function option_result_and_then<T, O, E>(
  * - Some(Err(e))    → Err(e)
  * - Some(Ok(t))     → Ok(Some(t))
  */
+/*#__NO_SIDE_EFFECTS__*/
 export function option_result_transpose<T, E>(
   o: Option<Result<T, E>>
 ): Result<Option<T>, E> {
@@ -127,6 +141,7 @@ export function option_result_transpose<T, E>(
 }
 
 /** Option<Promise<T>> → Promise<Option<T>>. */
+/*#__NO_SIDE_EFFECTS__*/
 export async function option_promise_transpose<T>(
   o: Option<Promise<T>>
 ): Promise<Option<T>> {


### PR DESCRIPTION
## Summary
- mark all ts/option functions and methods as `/*#__NO_SIDE_EFFECTS__*/`

## Testing
- `bazel run //:gazelle` *(fails: Error accessing registry https://bcr.bazel.build/ ... certificate_unknown)*
- `bazel test $(pwd)/ts/option:tests` *(fails: Error accessing registry https://bcr.bazel.build/ ... certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68c4650c720c832c967edc5ec1fb2a28