### PR TITLE
Attempt to fix the entrypoint missing issue for expire_on_delete.

### DIFF
--- a/ts/pulumi/lib/expire_on_delete/cmd/expire_on_delete/main.go
+++ b/ts/pulumi/lib/expire_on_delete/cmd/expire_on_delete/main.go
@@ -5,8 +5,8 @@
 // not percolated to the CDN yet, so it serves an old version of the file with
 // references to now removed content-addressible objects.
 //
-// You can set a lifecycle policy to delete objects with the "soft_deleted" tag
-// once this is set up.
+// You can set a lifecycle policy to delete objects with the "expire_on_delete"
+// tag once this is set up.
 package main
 
 import (
@@ -53,7 +53,7 @@ func processDeletedObject(ctx context.Context, client *s3.Client, bucket, key st
 		Key:    aws.String(key),
 		Tagging: &types.Tagging{
 			TagSet: []types.Tag{
-				{Key: aws.String("soft_deleted"), Value: aws.String("true")},
+				{Key: aws.String("expire_on_delete"), Value: aws.String("true")},
 			},
 		},
 	})

--- a/ts/pulumi/lib/expire_on_delete/expire_on_delete.ts
+++ b/ts/pulumi/lib/expire_on_delete/expire_on_delete.ts
@@ -139,7 +139,7 @@ export class S3ExpireOnDeletePolicy extends ComponentResource {
                     id: "ExpireSoftDeletedObjects",
                     filter: {
                         tag: {
-                            key: "soft_deleted",
+                            key: "expire_on_delete",
                             value: "true",
                         },
 						objectSizeGreaterThan: '0',


### PR DESCRIPTION

The below logs seem to show an attempt to find a /soft_delete, which
is what the entrypoint *was*, once, a long time ago. So maybe changing
the binary ref will fix it...


Logs:

```
/aws/lambda/monorepo_baby_babycomputer_expire_on_delete-lambda-2997065
2025/02/25/[$LATEST]82f131a348f9471c89193375b9eab8e3
Message

Timestamp

Message

No older events at this moment.
Retry
2025-02-25T07:53:48.388Z
INIT_REPORT Init Duration: 0.61 ms Phase: init Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:53:48.407Z
INIT_REPORT Init Duration: 0.61 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:53:48.407Z
START RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Version: $LATEST
2025-02-25T07:53:48.409Z
RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:53:48.409Z
END RequestId: 85c13605-3405-4e58-8f55-e74904b10148
2025-02-25T07:53:48.409Z
REPORT RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Duration: 2.81 ms Billed Duration: 3 ms Memory Size: 512 MB Max Memory Used: 3 MB
2025-02-25T07:53:56.035Z
INIT_REPORT Init Duration: 0.46 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:53:56.035Z
START RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Version: $LATEST
2025-02-25T07:53:56.035Z
RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:53:56.036Z
END RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd
2025-02-25T07:53:56.036Z
REPORT RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Duration: 1.40 ms Billed Duration: 2 ms Memory Size: 512 MB Max Memory Used: 2 MB
2025-02-25T07:53:56.052Z
INIT_REPORT Init Duration: 0.49 ms Phase: init Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:54:15.457Z
INIT_REPORT Init Duration: 0.45 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:54:15.457Z
START RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Version: $LATEST
2025-02-25T07:54:15.458Z
RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:54:15.458Z
END RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6
2025-02-25T07:54:15.458Z
REPORT RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Duration: 1.37 ms Billed Duration: 2 ms Memory Size: 512 MB Max Memory Used: 2 MB
2025-02-25T07:54:15.473Z
INIT_REPORT Init Duration: 0.54 ms Phase: init Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:54:24.845Z
INIT_REPORT Init Duration: 0.47 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:54:24.845Z
START RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Version: $LATEST
2025-02-25T07:54:24.846Z
RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:54:24.846Z
END RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f
2025-02-25T07:54:24.846Z
REPORT RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Duration: 1.49 ms Billed Duration: 2 ms Memory Size: 512 MB Max Memory Used: 2 MB
2025-02-25T07:54:24.862Z
INIT_REPORT Init Duration: 0.57 ms Phase: init Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:54:42.561Z
INIT_REPORT Init Duration: 0.76 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:54:42.561Z
START RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Version: $LATEST
2025-02-25T07:54:42.563Z
RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:54:42.563Z
END RequestId: 85c13605-3405-4e58-8f55-e74904b10148
2025-02-25T07:54:42.563Z
REPORT RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Duration: 2.67 ms Billed Duration: 3 ms Memory Size: 512 MB Max Memory Used: 3 MB
2025-02-25T07:54:42.579Z
INIT_REPORT Init Duration: 0.39 ms Phase: init Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:54:56.187Z
INIT_REPORT Init Duration: 0.47 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:54:56.187Z
START RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Version: $LATEST
2025-02-25T07:54:56.188Z
RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:54:56.188Z
END RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd
2025-02-25T07:54:56.188Z
REPORT RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Duration: 1.81 ms Billed Duration: 2 ms Memory Size: 512 MB Max Memory Used: 3 MB
2025-02-25T07:55:08.604Z
INIT_REPORT Init Duration: 0.47 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:55:08.604Z
START RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Version: $LATEST
2025-02-25T07:55:08.605Z
RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:55:08.605Z
END RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6
2025-02-25T07:55:08.605Z
REPORT RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Duration: 2.29 ms Billed Duration: 3 ms Memory Size: 512 MB Max Memory Used: 3 MB
2025-02-25T07:55:08.621Z
INIT_REPORT Init Duration: 0.51 ms Phase: init Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:55:21.010Z
INIT_REPORT Init Duration: 0.47 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:55:21.010Z
START RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Version: $LATEST
2025-02-25T07:55:21.011Z
RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:55:21.011Z
END RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f
2025-02-25T07:55:21.011Z
REPORT RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Duration: 2.25 ms Billed Duration: 3 ms Memory Size: 512 MB Max Memory Used: 3 MB
2025-02-25T07:56:49.714Z
INIT_REPORT Init Duration: 0.55 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:56:49.714Z
START RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Version: $LATEST
2025-02-25T07:56:49.716Z
RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:56:49.716Z
END RequestId: 85c13605-3405-4e58-8f55-e74904b10148
2025-02-25T07:56:49.716Z
REPORT RequestId: 85c13605-3405-4e58-8f55-e74904b10148 Duration: 2.40 ms Billed Duration: 3 ms Memory Size: 512 MB Max Memory Used: 3 MB
2025-02-25T07:56:49.733Z
INIT_REPORT Init Duration: 0.58 ms Phase: init Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:57:01.338Z
INIT_REPORT Init Duration: 0.46 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:57:01.338Z
START RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Version: $LATEST
2025-02-25T07:57:01.339Z
RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:57:01.339Z
END RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd
2025-02-25T07:57:01.339Z
REPORT RequestId: ff54c526-db9f-4ef7-9c9e-cffca9f009fd Duration: 1.83 ms Billed Duration: 2 ms Memory Size: 512 MB Max Memory Used: 2 MB
2025-02-25T07:57:16.753Z
INIT_REPORT Init Duration: 0.52 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:57:16.753Z
START RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Version: $LATEST
2025-02-25T07:57:16.755Z
RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:57:16.755Z
END RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6
2025-02-25T07:57:16.755Z
REPORT RequestId: ec586bef-f361-4038-9ffe-c22d01ef7da6 Duration: 2.43 ms Billed Duration: 3 ms Memory Size: 512 MB Max Memory Used: 3 MB
2025-02-25T07:57:18.162Z
INIT_REPORT Init Duration: 0.75 ms Phase: invoke Status: error Error Type: Runtime.InvalidEntrypoint
2025-02-25T07:57:18.162Z
START RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Version: $LATEST
2025-02-25T07:57:18.163Z
RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Error: fork/exec /soft_delete: no such file or directory Runtime.InvalidEntrypoint
2025-02-25T07:57:18.163Z
END RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f
2025-02-25T07:57:18.163Z
REPORT RequestId: 1efcf6b7-8b90-45c8-938e-138e4396c29f Duration: 2.44 ms Billed Duration: 3 ms Memory Size: 512 MB Max Memory Used: 3 MB
No newer events at this moment.
Auto retry paused.
```
