### PR TITLE
Disable autorun for non-sapling VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,15 +13,12 @@
 			},
 			"group": "build",
 			"problemMatcher": [],
-			"presentation": {
-				"reveal": "never",
-				"group": "preprep",
-				"close": true,
-				"panel": "dedicated",
-			},
-			"runOptions": {
-				"runOn": "folderOpen"
-			}
+                        "presentation": {
+                                "reveal": "never",
+                                "group": "preprep",
+                                "close": true,
+                                "panel": "dedicated",
+                        }
 		},
 		{
 			"label": "Python: Venv",
@@ -32,12 +29,9 @@
 				"run",
 				"//.vscode:activate_venv"
 			],
-			"runOptions": {
-				"runOn": "folderOpen"
-			},
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
+                        "options": {
+                                "cwd": "${workspaceFolder}"
+                        },
 			"presentation": {
 				"close": true,
 				"reveal": "never",


### PR DESCRIPTION
## Summary
- stop the Rust and Python VS Code tasks from auto-running when the workspace opens
- keep the Sapling bootstrap task configured to run on folder open

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d28caacb68832c9692adb531c3b198