### PR TITLE
Enforce @jest/globals imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -109,13 +109,14 @@ export default tseslint.config(
 			...tseslint.configs.recommended,
 			reactConfig
 		],
-		plugins: {
-			'@next/next': next,
-		},
-		rules: {
-			'@typescript-eslint/no-floating-promises': 'error',
-			'@typescript-eslint/no-misused-promises': 'error',
-			'@typescript-eslint/no-empty-interface': ['error', { allowSingleExtends: true }],
+        plugins: {
+                '@next/next': next,
+                'jest': jestLint,
+        },
+        rules: {
+                '@typescript-eslint/no-floating-promises': 'error',
+                '@typescript-eslint/no-misused-promises': 'error',
+                '@typescript-eslint/no-empty-interface': ['error', { allowSingleExtends: true }],
 			'@typescript-eslint/no-unused-vars': [
 				'error',
 				{
@@ -125,12 +126,13 @@ export default tseslint.config(
 					caughtErrorsIgnorePattern: '^_',
 					destructuredArrayIgnorePattern: '^_',
 					varsIgnorePattern: '^_',
-					ignoreRestSiblings: true,
-				},
-			],
-			'@typescript-eslint/no-non-null-assertion': 'off',
-			'@typescript-eslint/no-unnecessary-condition': 'error',
-		},
+                        ignoreRestSiblings: true,
+                },
+                ],
+                '@typescript-eslint/no-non-null-assertion': 'off',
+                '@typescript-eslint/no-unnecessary-condition': 'error',
+                'jest/prefer-importing-jest-globals': 'error',
+        },
 	},
 	{
 		name: 'markdown',


### PR DESCRIPTION
## Summary
- add the eslint-plugin-jest instance to the base config
- enforce the jest/prefer-importing-jest-globals rule for all JS/TS files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df2fc5c3d8832ca1c0a896c681052c