### PR TITLE
Back out "Prepare AWS for workload identity."

### DIFF
--- a/ts/pulumi/index.ts
+++ b/ts/pulumi/index.ts
@@ -40,88 +40,6 @@ export class Component extends Pulumi.ComponentResource {
 			args.staging? 'staging': 'production'
 		))
 
-		const accountId = Pulumi.output(aws.getCallerIdentity({})).accountId;
-
-		// Shared GitHub Actions OIDC provider and roles so CI can assume AWS
-		// credentials without long‑lived keys.
-		const githubOidcProvider = new aws.iam.OpenIdConnectProvider(
-			`${name}_github_oidc_provider`,
-			{
-				clientIdLists: ['sts.amazonaws.com'],
-				thumbprintLists: ['6938fd4d98bab03faadb97b34396831e3780aea1'],
-				url: 'https://token.actions.githubusercontent.com',
-			},
-			{ parent: this }
-		);
-
-		const githubAssumeRolePolicy = (
-			subjects: Pulumi.Input<Pulumi.Input<string>[]>
-		) =>
-			Pulumi.all([githubOidcProvider.arn, subjects]).apply(
-				([providerArn, subjectPatterns]) =>
-					JSON.stringify({
-						Version: '2012-10-17',
-						Statement: [
-							{
-								Effect: 'Allow',
-								Principal: { Federated: providerArn },
-								Action: 'sts:AssumeRoleWithWebIdentity',
-								Condition: {
-									StringEquals: {
-										'token.actions.githubusercontent.com:aud':
-											'sts.amazonaws.com',
-									},
-									StringLike: {
-										'token.actions.githubusercontent.com:sub':
-											subjectPatterns,
-									},
-								},
-							},
-						],
-					})
-			);
-
-		const stagingSubjects = [
-			'repo:zemn-me/monorepo:ref:refs/heads/main',
-			'repo:zemn-me/monorepo:ref:refs/heads/gh-readonly-queue/*',
-		];
-
-		const productionSubjects = ['repo:zemn-me/monorepo:ref:refs/heads/main'];
-
-		const githubActionsStagingRole = new aws.iam.Role(
-			`${name}_github_actions_staging_role`,
-			{
-				assumeRolePolicy: githubAssumeRolePolicy(stagingSubjects),
-				tags,
-			},
-			{ parent: this }
-		);
-
-		const githubActionsProdRole = new aws.iam.Role(
-			`${name}_github_actions_prod_role`,
-			{
-				assumeRolePolicy: githubAssumeRolePolicy(productionSubjects),
-				tags,
-			},
-			{ parent: this }
-		);
-
-		const githubActionRoles: Array<{ label: 'staging' | 'prod'; role: aws.iam.Role }> = [
-			{ label: 'staging', role: githubActionsStagingRole },
-			{ label: 'prod', role: githubActionsProdRole },
-		];
-
-		githubActionRoles.forEach(({ label, role }) => {
-			new aws.iam.RolePolicyAttachment(
-				`${name}_github_actions_${label}_admin`,
-				{
-					role: role.name,
-					policyArn: 'arn:aws:iam::aws:policy/AdministratorAccess',
-				},
-				{ parent: this }
-			);
-		});
-
 		new CostAllocationTag(
 			`${name}_cost_tag`,
 			{
@@ -289,9 +207,6 @@ export class Component extends Pulumi.ComponentResource {
 		super.registerOutputs({
 			pleaseIntroduceMeToYourDog: this.pleaseIntroduceMeToYourDog,
 			eggsForDogsDotComZoneId,
-			githubActionsProdRoleArn: githubActionsProdRole.arn,
-			githubActionsStagingRoleArn: githubActionsStagingRole.arn,
-			awsAccountId: accountId,
 		});
 	}
 }


### PR DESCRIPTION

Was failing because IAM OIDC providers are singleton.

AM: CreateOpenIDConnectProvider, https response error StatusCode: 409, RequestID: 8e7afba2-89d0-4742-816e-63c3e7b5baea, EntityAlreadyExists: Provider with url https://token.actions.githubusercontent.com already exists.: provider=aws@6.68.0
     +  aws:iam:OpenIdConnectProvider monorepo_github_oidc_provider creating (0s) error: 1 error occurred:
     +  aws:iam:OpenIdConnectProvider monorepo_github_oidc_provider **creating failed** error: 1 error occurred:
    @ Updating.....
        pulumi:pulumi:Stack monorepo-2-prod running error: update failed
    @ Updating.....
        pulumi:pulumi:Stack monorepo-2-prod **failed** 1 error
     ~  ts:pulumi:zemn.me:hello_world monorepo_zemn.me_fargate_img updated [diff: ~token]
    Diagnostics:
      pulumi:pulumi:Stack (monorepo-2-prod):
        error: update failed

      aws:iam:OpenIdConnectProvider (monorepo_github_oidc_provider):
        error:   sdk-v2/provider2.go:515: sdk.helper_schema: creating IAM OIDC Provider: operation error IAM: CreateOpenIDConnectProvider, https response error StatusCode: 409, RequestID: 8e7afba2-89d0-4742-816e-63c3e7b5baea, EntityAlreadyExists: Provider with url https://token.actions.githubusercontent.com already exists.: provider=aws@6.68.0
        error: 1 error occurred:
        	* creating IAM OIDC Provider: operation error IAM: CreateOpenIDConnectProvider, https response error StatusCode: 409, RequestID: 8e7afba2-89d0-4742-816e-63c3e7b5baea, EntityAlreadyExists: Provider with url https://token.actions.githubusercontent.com already exists.

        [Pulumi Neo] Would you like help with these diagnostics?
        https://app.pulumi.com/Zemnmez/monorepo-2/prod/updates/15075?explainFailure

    Resources:
        ~ 2 updated
        49 unchanged
        2 errored

    Duration: 10s


Original commit changeset: 829a4100c0c5
