### PR TITLE
Add a cache key response to useOIDC so that downstream queries can be cache busted.

### DIFF
--- a/project/zemn.me/hook/useOIDC.tsx
+++ b/project/zemn.me/hook/useOIDC.tsx
@@ -1,4 +1,4 @@
-import { SkipToken, skipToken, useQuery } from '@tanstack/react-query';
+import { QueryKey, SkipToken, skipToken, useQuery } from '@tanstack/react-query';
 
 import { useOIDCConfig } from '#root/project/zemn.me/hook/useOIDCConfig.js';
 import {
@@ -38,6 +38,8 @@ export function useOIDC(issuer: string, params: OIDCImplicitRequest): [
 	id_token: Future<string, void, Error>,
 	access_token: Future<string, void, Error>,
 	promptForLogin: Future<() => Promise<void>, void, Error>,
+	/** can use to cache bust dependent queries */
+	cacheKey: QueryKey
 ] {
 	const oidc_config = useOIDCConfig(issuer);
 
@@ -78,7 +80,7 @@ export function useOIDC(issuer: string, params: OIDCImplicitRequest): [
 			return u;
 		}
 	)
-	const cacheKeyArgs = [issuer, params];
+	const cacheKeyArgs: QueryKey = [issuer, params];
 
 	// very close but we need to abstract and pipeline this more cleanly.
 
@@ -165,5 +167,10 @@ export function useOIDC(issuer: string, params: OIDCImplicitRequest): [
 	));
 
 
-	return [id_token, access_token, requestConsent] as const;
+	return [
+		id_token,
+		access_token,
+		requestConsent,
+		cacheKeyArgs,
+	] as const;
 }

--- a/project/zemn.me/hook/useZemnMeAuth.tsx
+++ b/project/zemn.me/hook/useZemnMeAuth.tsx
@@ -13,7 +13,7 @@ import { option_from_maybe_undefined } from '#root/ts/option/types.js';
 
 export function useZemnMeAuth() {
 	const apiFetchClient = useFetchClient();
-	const [fut_id_token, fut_google_access_token, fut_promptForLogin] = useGoogleAuth([
+	const [fut_id_token, fut_google_access_token, fut_promptForLogin, cacheKey] = useGoogleAuth([
 	]);
 
 	const request_body = future_and_then(
@@ -29,7 +29,7 @@ export function useZemnMeAuth() {
 
 
 	const exchangedTokenRsp = useQueryFuture(useQuery({
-		queryKey: ['zemn-me-oidc-id-token'],
+		queryKey: ['zemn-me-oidc-id-token', ...cacheKey],
 		queryFn: request_body(
 			body => () => apiFetchClient
 			.POST('/oauth2/token', {


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
* #11831
* __->__ #11826