### PR TITLE
Fix OpenAI link safety URL in bio timeline

### DIFF
--- a/project/zemn.me/bio/bio.ts
+++ b/project/zemn.me/bio/bio.ts
@@ -853,7 +853,7 @@ export const Bio = {
 					title: en`Keeping your data safe when an AI agent clicks a link`,
 					id: "1a8b03ca-415a-4e30-bf2c-1f9969779e1a",
 					description: en`Blog post summarising paper describing the mechanism OpenAI products such as ChatGPT use to detect when an AI is communicating non-public data.`,
-					url: url`https://openai.com/index/ai-agent-link-safety/1`,
+					url: url`https://openai.com/index/ai-agent-link-safety`,
 					tags: [work, security, writing],
 				}
         ],


### PR DESCRIPTION
### Motivation
- Remove an incorrect trailing path segment (`/1/`) from the OpenAI link safety blog URL in the bio timeline so the link points to the canonical article.

### Description
- Replace `https://openai.com/index/ai-agent-link-safety/1` with `https://openai.com/index/ai-agent-link-safety` in `project/zemn.me/bio/bio.ts`.

### Testing
- Ran `bazel run //:gazelle` which completed successfully.
- Ran `bazel test //project/zemn.me/bio:test` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a9ac056bc832c929c56fbe645e495)