### PR TITLE
Update Lockdown Mode bio wording for ChatGPT specificity

### DIFF
--- a/project/zemn.me/bio/bio.ts
+++ b/project/zemn.me/bio/bio.ts
@@ -861,7 +861,7 @@ export const Bio = {
 					date: date(13, 'feb', 2026),
 					title: en`Introducing Lockdown Mode and Elevated Risk labels in ChatGPT`,
 					id: "68408DCB-0B05-451B-8CED-DAD64CDE41B7",
-					description: en`Blog post summarising a fully sandboxed mode which mitigates impacts from Prompt Injection.`,
+					description: en`Blog post summarising a fully sandboxed mode for chatgpt which mitigates impacts from Prompt Injection.`,
 					tags: [work, security],
 				}
 


### PR DESCRIPTION
### Motivation
- Make the timeline description explicit that the lockdown/sandboxed mode refers to ChatGPT by updating the wording in the bio entry in `project/zemn.me/bio/bio.ts`.

### Description
- Replace the description text in `project/zemn.me/bio/bio.ts` from `a fully sandboxed mode` to `a fully sandboxed mode for chatgpt` for the Lockdown Mode timeline entry.

### Testing
- Ran `bazel test //project/zemn.me/bio/...` and observed substantial build/test progress, but the full test run did not complete within this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698feff4bbcc832c99042a76982cf6bc)