### PR TITLE
Fix Quaternion.fromAxisAngle (normalize axis), add tests, unskip multiplication

### DIFF
--- a/ts/math/quaternion.ts
+++ b/ts/math/quaternion.ts
@@ -4,7 +4,7 @@
  * for handling rotations in 3D space.
  */
 
-import { point, Point3D, x, y, z } from "#root/ts/math/cartesian.js";
+import { magnitude, point, Point3D, x, y, z } from "#root/ts/math/cartesian.js";
 
 export class Quaternion<
 	X extends number = number,
@@ -107,11 +107,17 @@ export class Quaternion<
 	static fromAxisAngle(axis: Point3D, angle: number): Quaternion {
 		const halfAngle = angle * 0.5;
 		const s = Math.sin(halfAngle);
+		const axisLength = magnitude(axis);
+
+		if (axisLength === 0) {
+			throw new Error('Cannot construct a quaternion from a zero-length axis.');
+		}
+
 		return new Quaternion(
-			x(axis)* s,
-			y(axis)* s,
-			z(axis)* s,
+			x(axis) / axisLength * s,
+			y(axis) / axisLength * s,
+			z(axis) / axisLength * s,
 			Math.cos(halfAngle)
-		).normalize();
+		);
 	}
 }

--- a/ts/math/quaternion_test.ts
+++ b/ts/math/quaternion_test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
+import { point } from '#root/ts/math/cartesian.js';
 import { Quaternion } from '#root/ts/math/quaternion.js'; // Adjust the import path accordingly
 describe('Quaternion arithmetic', () => {
 	test('addition', () => {
@@ -24,14 +25,14 @@ describe('Quaternion arithmetic', () => {
 		expect(result.w).toBeCloseTo(3);
 	});
 
-	test.skip('multiplication', () => {
+	test('multiplication', () => {
 		const q1 = new Quaternion(1, 2, 3, 4);
 		const q2 = new Quaternion(4, 3, 2, 1);
 
 		const result = q1.multiply(q2);
-		expect(result.x).toBeCloseTo(-12);
-		expect(result.y).toBeCloseTo(6);
-		expect(result.z).toBeCloseTo(24);
+		expect(result.x).toBeCloseTo(12);
+		expect(result.y).toBeCloseTo(24);
+		expect(result.z).toBeCloseTo(6);
 		expect(result.w).toBeCloseTo(-12);
 	});
 
@@ -52,5 +53,27 @@ describe('Quaternion arithmetic', () => {
 		expect(normalizedQ.y).toBeCloseTo(expectedNormalizedQ.y, 4);
 		expect(normalizedQ.z).toBeCloseTo(expectedNormalizedQ.z, 4);
 		expect(normalizedQ.w).toBeCloseTo(expectedNormalizedQ.w, 4);
+	});
+
+	test('fromAxisAngle ignores axis scale', () => {
+		const ninetyDegrees = Math.PI / 2;
+		const unitAxis = point<3>(0, 1, 0);
+		const scaledAxis = point<3>(0, 5, 0);
+
+		const fromUnit = Quaternion.fromAxisAngle(unitAxis, ninetyDegrees);
+		const fromScaled = Quaternion.fromAxisAngle(scaledAxis, ninetyDegrees);
+
+		expect(fromScaled.x).toBeCloseTo(fromUnit.x);
+		expect(fromScaled.y).toBeCloseTo(fromUnit.y);
+		expect(fromScaled.z).toBeCloseTo(fromUnit.z);
+		expect(fromScaled.w).toBeCloseTo(fromUnit.w);
+	});
+
+	test('fromAxisAngle rejects a zero axis', () => {
+		const axis = point<3>(0, 0, 0);
+
+		expect(() => Quaternion.fromAxisAngle(axis, Math.PI / 4)).toThrow(
+			'Cannot construct a quaternion from a zero-length axis.'
+		);
 	});
 });


### PR DESCRIPTION
### Motivation
- Axis-angle quaternion construction used the raw axis magnitude which made rotations depend on axis scale and could produce incorrect quaternions for non-unit axes.
- The multiplication test was skipped and the expected Hamilton product components were incorrect, reducing test coverage for core quaternion arithmetic.
- Need explicit handling of degenerate input (zero-length axis) to fail early and clearly.

### Description
- Normalize the input axis inside `Quaternion.fromAxisAngle` by importing and using `magnitude` and dividing the axis components by the axis length before applying `sin(halfAngle)`, instead of normalizing the final quaternion.{ts/math/quaternion.ts}
- Add an explicit error throw when `fromAxisAngle` receives a zero-length axis to prevent invalid construction.{ts/math/quaternion.ts}
- Remove the trailing `.normalize()` on the returned quaternion from `fromAxisAngle` (the axis normalization handles the necessary scaling).{ts/math/quaternion.ts}
- Unskip the multiplication test and correct the expected Hamilton product values, and add tests verifying that `fromAxisAngle` is invariant to axis scale and rejects a zero-length axis; also import `point` in the test file.{ts/math/quaternion_test.ts}

### Testing
- Ran `bazel test //ts/math:tests` and the test target passed: `//ts/math:tests PASSED`.
- Ran `bazel run //:gazelle` to refresh workspace metadata and it completed successfully.
- The updated test suite includes new tests for axis-scale invariance and zero-axis rejection and they passed under the Bazel test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925643e8ec832c900c87b3b4aa1c11)