### PR TITLE
Remove admin sync status indicator and simplify admin settings E2E test

### DIFF
--- a/project/zemn.me/testing/admin_test.go
+++ b/project/zemn.me/testing/admin_test.go
@@ -41,9 +41,6 @@ func TestAdminSettingsEndToEnd(t *testing.T) {
 		t.Fatalf("oidc login: %v", err)
 	}
 
-	syncIndicatorSelector := "output[aria-label='Callbox settings status']"
-	syncIndicatorSyncedSelector := syncIndicatorSelector + "[aria-busy='false']"
-	syncIndicatorBusySelector := syncIndicatorSelector + "[aria-busy='true']"
 	uidValueSelector := "output[aria-label='Admin UID value']"
 	if err := waitForText(driver, "You are logged in.", 30*time.Second); err != nil {
 		body, _ := driver.ExecuteScript("return document.body ? document.body.innerHTML : ''", nil)
@@ -52,9 +49,6 @@ func TestAdminSettingsEndToEnd(t *testing.T) {
 	if _, err := waitForElement(driver, selenium.ByCSSSelector, uidValueSelector, 30*time.Second); err != nil {
 		body, _ := driver.ExecuteScript("return document.body ? document.body.innerHTML : ''", nil)
 		t.Fatalf("wait for admin uid output: %v (body snippet: %v)", err, body)
-	}
-	if _, err := waitForElement(driver, selenium.ByCSSSelector, syncIndicatorSyncedSelector, 30*time.Second); err != nil {
-		t.Fatalf("initial settings sync: %v", err)
 	}
 	if err := expectElementText(driver, uidValueSelector, oidc.LocalSubject, 10*time.Second); err != nil {
 		t.Fatalf("admin uid mismatch: %v", err)
@@ -134,12 +128,6 @@ func TestAdminSettingsEndToEnd(t *testing.T) {
 	if err := submit.Click(); err != nil {
 		t.Fatalf("submit admin form: %v", err)
 	}
-	if _, err := waitForElement(driver, selenium.ByCSSSelector, syncIndicatorBusySelector, 5*time.Second); err != nil {
-		t.Fatalf("settings sync indicator did not enter pending state: %v", err)
-	}
-	if _, err := waitForElement(driver, selenium.ByCSSSelector, syncIndicatorSyncedSelector, 30*time.Second); err != nil {
-		t.Fatalf("settings sync indicator did not return to synced: %v", err)
-	}
 
 	if err := driver.Get(adminURL.String()); err != nil {
 		t.Fatalf("reload admin after save: %v", err)
@@ -151,9 +139,6 @@ func TestAdminSettingsEndToEnd(t *testing.T) {
 	}
 	if err := expectElementText(driver, uidValueSelector, oidc.LocalSubject, 10*time.Second); err != nil {
 		t.Fatalf("admin uid mismatch after reload: %v", err)
-	}
-	if _, err := waitForElement(driver, selenium.ByCSSSelector, syncIndicatorSyncedSelector, 30*time.Second); err != nil {
-		t.Fatalf("settings sync indicator after reload: %v", err)
 	}
 
 	if err := expectInputValue(driver, "input[id$='fallbackPhone']", fallbackValue, 10*time.Second); err != nil {


### PR DESCRIPTION
### Motivation
- The transient "Sync status: ..." output added UI noise and produced brittle coupling with the end-to-end test, so it should be removed. 
- The admin settings test should continue to verify persistence but in a more robust way that doesn't depend on ephemeral UI state. 

### Description
- Removed the sync-status UI and all related snapshot/sync state logic from `project/zemn.me/app/admin/client.tsx`, including the `useMemo`/`useState` usage, snapshot normalization, and the `Sync status` output. 
- Simplified the Selenium E2E test in `project/zemn.me/testing/admin_test.go` to stop querying the removed status element, removed the `waitForPersistedAdminSettings` helper, and instead reload `/admin` and assert saved values via `expectElementText` and `expectInputValue`. 
- Minor formatting and cleanup applied to the modified files so the admin bundle and tests reference remain consistent. 

### Testing
- Ran `bazel run //:gazelle` which completed successfully. 
- Built the admin bundle with `bazel build //project/zemn.me/app/admin:admin` which completed successfully. 
- Ran `bazel test //project/zemn.me/testing:testing_test` which failed in this environment due to missing integration server-root metadata and Chromium startup errors in the Selenium sandbox, so the full E2E suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996553e0134832c887a1b3450e161bf)