### PR TITLE
Shorten callbox key unlock window to 2 minutes

### DIFF
--- a/project/zemn.me/api/server/key_requests.go
+++ b/project/zemn.me/api/server/key_requests.go
@@ -14,7 +14,7 @@ import (
 
 const callboxKeyPartition = "CALLBOX_KEY_REQUESTS"
 const callboxDoorOpenPartition = "CALLBOX_DOOR_OPEN_EVENTS"
-const doorOpenDuration = 4 * time.Minute
+const doorOpenDuration = 2 * time.Minute
 
 type KeyRequestRecord struct {
 	Id      string `dynamodbav:"id"`


### PR DESCRIPTION
### Motivation
- Reduce the callbox door-open interval so pressing the lock button on `/key` opens the door for two minutes instead of the previous longer window.

### Description
- Change the `doorOpenDuration` constant in `project/zemn.me/api/server/key_requests.go` from `4 * time.Minute` to `2 * time.Minute`, which shortens the `/callbox` status `open`/`openUntil` window used by the `/key` flow.

### Testing
- Ran `bazel run //:gazelle` successfully, and attempted `bazel test //project/zemn.me/api/server:server_test --test_filter=TestGetCallbox` but the test run required a very long toolchain compile and was terminated before completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4dabd8c00832cb4e5bdb0547629a5)