### PR TITLE
Grant `callbox_key` scope to `keng` in hardcoded OIDC scopes

### DIFF
--- a/project/zemn.me/api/server/token_exchange.go
+++ b/project/zemn.me/api/server/token_exchange.go
@@ -133,6 +133,7 @@ func hardcodedScopesForSubject(subject OIDCSubject) []string {
 		}
 	case "keng":
 		return []string{
+			"callbox_key",
 			"grievance_portal",
 		}
 	default:


### PR DESCRIPTION
### Motivation
- Add the `callbox_key` scope to the `keng` identity so that this subject receives callbox key access during token exchange.

### Description
- Update `hardcodedScopesForSubject` in `project/zemn.me/api/server/token_exchange.go` to include the string `"callbox_key"` in the `keng` case.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30b438f80832caacfecb34049b43e)