### PR TITLE
Add Tweet archive experiment and expose exact-date title in Date component

### DIFF
--- a/project/zemn.me/app/experiments/page.tsx
+++ b/project/zemn.me/app/experiments/page.tsx
@@ -12,6 +12,7 @@ const pages = {
 	"/experiments/toc": "Test renderer for table of contents generation.",
 	"/experiments/article": "Test renderer for MDX.",
 	"/experiments/cv": "Unfinished attempt to port my CV to my modern site.",
+	"/experiments/tweets": "Archive viewer for every old tweet.",
 
 }
 

--- a/project/zemn.me/app/experiments/tweets/BUILD.bazel
+++ b/project/zemn.me/app/experiments/tweets/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//bzl:rules.bzl", "bazel_lint")
+load("//ts:rules.bzl", "ts_project")
+
+ts_project(
+    name = "tweets",
+    srcs = ["page.tsx"],
+    assets = ["page.css"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/react",
+        "//:node_modules/@types/react-dom",
+        "//:node_modules/next",
+        "//:node_modules/react",
+        "//:node_modules/react-dom",
+        "//:node_modules/zod",
+        "//project/zemn.me/components/Link",
+        "//ts/next.js/types/next-compiled",
+        "//ts/react/lang",
+        "//ts/twitter",
+    ],
+)
+
+filegroup(
+    name = "all_ts_srcs",
+    srcs = ["page.tsx"],
+    visibility = ["//:__subpackages__"],
+)
+
+bazel_lint(
+    name = "bazel_lint",
+    srcs = ["BUILD.bazel"],
+)

--- a/project/zemn.me/app/experiments/tweets/page.css
+++ b/project/zemn.me/app/experiments/tweets/page.css
@@ -1,0 +1,99 @@
+.tweets-page {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	padding-block-end: 4rem;
+}
+
+.tweets-page-header {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.tweets-title {
+	margin: 0;
+	font-size: clamp(1.5rem, 1rem + 1.2vw, 2.4rem);
+}
+
+.tweets-subtitle,
+.tweets-count {
+	margin: 0;
+	color: rgb(115, 115, 115);
+}
+
+.tweets-timeline {
+	display: flex;
+	flex-direction: column;
+	gap: 0.9rem;
+}
+
+.tweet-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding: 1rem;
+	border: 1px solid rgb(225, 225, 225);
+	border-radius: 0.75rem;
+	background: rgb(255, 255, 255);
+}
+
+.tweet-header {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 0.5rem 1rem;
+}
+
+.tweet-permalink {
+	text-decoration: none;
+	color: inherit;
+}
+
+.tweet-permalink:hover {
+	text-decoration: underline;
+}
+
+.tweet-metrics {
+	display: flex;
+	gap: 0.8rem;
+	font-variant-numeric: tabular-nums;
+	color: rgb(99, 99, 99);
+	font-size: 0.95rem;
+}
+
+.tweet-text {
+	margin: 0;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	line-height: 1.45;
+}
+
+.tweet-media-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+	gap: 0.6rem;
+	padding: 0;
+	margin: 0;
+	list-style: none;
+}
+
+.tweet-media-item {
+	position: relative;
+	border-radius: 0.6rem;
+	overflow: hidden;
+	background: rgb(245, 245, 245);
+}
+
+.tweet-media-image {
+	display: block;
+	width: 100%;
+	height: auto;
+}
+
+@media (width <= 640px) {
+	.tweet-card {
+		padding: 0.8rem;
+	}
+}

--- a/project/zemn.me/app/experiments/tweets/page.tsx
+++ b/project/zemn.me/app/experiments/tweets/page.tsx
@@ -1,0 +1,189 @@
+import './page.css';
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { Metadata } from 'next/types';
+import { z } from 'zod';
+
+import Link from '#root/project/zemn.me/components/Link/index.js';
+import { Date } from '#root/ts/react/lang/date.js';
+import { archivedTweetSchema } from '#root/ts/twitter/archive.js';
+
+const mediaItemSchema = z.object({
+	id_str: z.string().optional(),
+	media_url: z.string().optional(),
+	media_url_https: z.string().optional(),
+	url: z.string().optional(),
+	display_url: z.string().optional(),
+	expanded_url: z.string().optional(),
+	type: z.string().optional(),
+});
+
+type ArchivedTweet = z.TypeOf<typeof archivedTweetSchema>;
+type TweetMedia = z.TypeOf<typeof mediaItemSchema>;
+
+interface TweetViewModel {
+	readonly id: string;
+	readonly createdAt: globalThis.Date;
+	readonly text: string;
+	readonly favoriteCount: number;
+	readonly retweetCount: number;
+	readonly media: readonly TweetMedia[];
+}
+
+const ARCHIVE_ROOT = path.join(process.cwd(), 'project/twitter_archive');
+
+async function getJsonFiles(dir: string): Promise<string[]> {
+	const entries = await fs.readdir(dir, { withFileTypes: true });
+	const nested = await Promise.all(entries.map(async entry => {
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			return getJsonFiles(fullPath);
+		}
+		if (entry.isFile() && entry.name.endsWith('.json') && entry.name !== 'index.json') {
+			return [fullPath];
+		}
+		return [];
+	}));
+	return nested.flat();
+}
+
+function toNumber(value: string | undefined): number {
+	if (value === undefined) {
+		return 0;
+	}
+	const n = Number.parseInt(value, 10);
+	return Number.isFinite(n) ? n : 0;
+}
+
+function uniqueMedia(media: readonly TweetMedia[]): TweetMedia[] {
+	const seen = new Set<string>();
+	return media.filter(item => {
+		const key = item.id_str ?? item.media_url_https ?? item.media_url ?? item.url;
+		if (key === undefined) {
+			return false;
+		}
+		if (seen.has(key)) {
+			return false;
+		}
+		seen.add(key);
+		return true;
+	});
+}
+
+function parseMediaCollection(media: unknown[] | undefined): TweetMedia[] {
+	if (media === undefined) {
+		return [];
+	}
+	const parsedMedia: TweetMedia[] = [];
+	for (const item of media) {
+		const parsedItem = mediaItemSchema.safeParse(item);
+		if (parsedItem.success) {
+			parsedMedia.push(parsedItem.data);
+		}
+	}
+	return parsedMedia;
+}
+
+function toTweetViewModel(json: ArchivedTweet): TweetViewModel | undefined {
+	const { tweet } = json;
+	const createdAt = new globalThis.Date(tweet.created_at);
+	if (Number.isNaN(createdAt.valueOf())) {
+		return undefined;
+	}
+	const allMedia = [
+		...parseMediaCollection(tweet.entities.media),
+		...parseMediaCollection(tweet.extended_entities?.media),
+	];
+
+	return {
+		id: tweet.id_str,
+		createdAt,
+		text: tweet.full_text,
+		favoriteCount: toNumber(tweet.favorite_count),
+		retweetCount: toNumber(tweet.retweet_count),
+		media: uniqueMedia(allMedia),
+	};
+}
+
+async function getTweets(): Promise<TweetViewModel[]> {
+	try {
+		const files = await getJsonFiles(ARCHIVE_ROOT);
+		const records = await Promise.all(files.map(async file => {
+			const raw = await fs.readFile(file, 'utf8');
+			const parsedTweet = archivedTweetSchema.safeParse(JSON.parse(raw));
+			if (!parsedTweet.success) {
+				return undefined;
+			}
+			return toTweetViewModel(parsedTweet.data);
+		}));
+		return records.filter((tweet): tweet is TweetViewModel => tweet !== undefined)
+			.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf());
+	} catch {
+		return [];
+	}
+}
+
+function TweetCard({ tweet }: { readonly tweet: TweetViewModel }) {
+	return (
+		<article className="tweet-card">
+			<header className="tweet-header">
+				<Link
+					className="tweet-permalink"
+					href={`https://x.com/i/status/${tweet.id}`}
+					rel="noreferrer"
+					target="_blank"
+				>
+					<Date date={tweet.createdAt} />
+				</Link>
+				<div className="tweet-metrics">
+					<span>♥ {tweet.favoriteCount.toLocaleString('en-US')}</span>
+					<span>↻ {tweet.retweetCount.toLocaleString('en-US')}</span>
+				</div>
+			</header>
+			<p className="tweet-text">{tweet.text}</p>
+			{tweet.media.length > 0 ? (
+				<ul className="tweet-media-grid">
+					{tweet.media.map(media => {
+						const src = media.media_url_https ?? media.media_url;
+						if (src === undefined) {
+							return null;
+						}
+						const alt = media.display_url ?? media.expanded_url ?? 'Tweet media';
+						return (
+							<li className="tweet-media-item" key={media.id_str ?? src}>
+								<img alt={alt} className="tweet-media-image" decoding="async" loading="lazy" src={src} />
+							</li>
+						);
+					})}
+				</ul>
+			) : null}
+		</article>
+	);
+}
+
+export default async function Page() {
+	const tweets = await getTweets();
+
+	return (
+		<div className="tweets-page">
+			<header className="tweets-page-header">
+				<h1 className="tweets-title">Tweet archive</h1>
+				<p className="tweets-subtitle">Every archived tweet in one scrollable timeline.</p>
+				<p className="tweets-count">{tweets.length.toLocaleString('en-US')} tweets</p>
+			</header>
+
+			<div className="tweets-timeline">
+				{tweets.map(tweet => (
+					<TweetCard key={tweet.id} tweet={tweet} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+export const metadata: Metadata = {
+	title: 'Tweet archive experiment',
+	description: 'A browsable timeline of archived tweets.',
+};

--- a/ts/react/lang/date.tsx
+++ b/ts/react/lang/date.tsx
@@ -14,7 +14,8 @@ export type SupportedDateInput = Temporal.ZonedDateTime | globalThis.Date;
 
 export interface DateProps {
 	readonly date: SupportedDateInput;
-	readonly className?: string
+	readonly className?: string;
+	readonly showExactTitle?: boolean;
 }
 
 function isTemporalZonedDateTime(value: SupportedDateInput): value is Temporal.ZonedDateTime {
@@ -135,7 +136,12 @@ export const Date = memo(function DateComponent(props: DateProps) {
 	}
 
 	return (
-		<time className={props.className} dateTime={zonedDate.toString()} lang={locale.toString()}>
+		<time
+			className={props.className}
+			dateTime={zonedDate.toString()}
+			lang={locale.toString()}
+			title={props.showExactTitle === false ? undefined : zonedDate.toString()}
+		>
 			{content}
 		</time>
 	);
@@ -151,7 +157,12 @@ export const MonthYear = memo(function MonthYearComponent(props: DateProps) {
 	const text = formatMonthYear(zonedDate, locale);
 
 	return (
-		<time className={props.className} dateTime={zonedDate.toString()} lang={locale.toString()}>{text}</time>
+		<time
+			className={props.className}
+			dateTime={zonedDate.toString()}
+			lang={locale.toString()}
+			title={props.showExactTitle === false ? undefined : zonedDate.toString()}
+		>{text}</time>
 	);
 });
 


### PR DESCRIPTION
### Motivation

- Add a browsable tweet-archive experiment to surface archived tweets as a scrollable timeline. 
- Wire the experiment into the experiments nav so it is discoverable from the experiments index. 
- Allow callers of the `Date` component to opt out of showing the exact zoned-date string as a `title` attribute for cleaner markup when desired.

### Description

- Added a new tweets experiment at `project/zemn.me/app/experiments/tweets` including `page.tsx`, `page.css`, and a Bazel `BUILD.bazel` that defines a `ts_project` target and `bazel_lint` target. 
- Implemented server-side JSON discovery and parsing logic in `page.tsx` to read tweet archive JSON files from `project/twitter_archive`, normalize and validate records with `zod`, deduplicate media, and render a timeline of `TweetCard` components. 
- Updated the experiments index `project/zemn.me/app/experiments/page.tsx` to add the `/experiments/tweets` entry. 
- Extended the date component `ts/react/lang/date.tsx` with a new optional prop `showExactTitle?: boolean` and added `title={...}` to `time` elements so the exact zoned date can be suppressed when `showExactTitle` is `false`.

### Testing

- Ran TypeScript type-checking on the changes and built the new Bazel target with `bazel build //project/zemn.me/app/experiments/tweets:tweets`, which succeeded. 
- Executed the repository lint target for the new BUILD with `bazel build //project/zemn.me/app/experiments/tweets:bazel_lint`, which succeeded. 
- Performed local smoke rendering by loading the page in dev mode to verify the timeline and date formatting render as expected with no runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1397c9390832cb47bc506a44b4ceb)