### PR TITLE
Add bottom-left HUD joystick for penguin meeting game

### DIFF
--- a/ts/pulumi/baby.computer/app/BUILD.bazel
+++ b/ts/pulumi/baby.computer/app/BUILD.bazel
@@ -5,6 +5,7 @@ ts_project(
     name = "app",
     srcs = [
         "client.tsx",
+        "controls.ts",
         "layout.tsx",
         "page.tsx",
         "scene.ts",
@@ -25,7 +26,10 @@ ts_project(
 
 ts_project(
     name = "app_tests",
-    srcs = ["scene_test.ts"],
+    srcs = [
+        "controls_test.ts",
+        "scene_test.ts",
+    ],
     visibility = ["//:__subpackages__"],
     deps = [
         ":app",
@@ -37,7 +41,10 @@ ts_project(
 
 jest_test(
     name = "tests",
-    srcs = ["scene_test.js"],
+    srcs = [
+        "controls_test.js",
+        "scene_test.js",
+    ],
     visibility = ["//:__subpackages__"],
     deps = [":app_tests"],
 )
@@ -46,6 +53,8 @@ filegroup(
     name = "all_ts_srcs",
     srcs = [
         "client.tsx",
+        "controls.ts",
+        "controls_test.ts",
         "layout.tsx",
         "page.tsx",
         "scene.ts",

--- a/ts/pulumi/baby.computer/app/client.tsx
+++ b/ts/pulumi/baby.computer/app/client.tsx
@@ -22,6 +22,10 @@ import {
 	createPenguinWorld,
 	nearestVisiblePenguin,
 } from '#root/ts/pulumi/baby.computer/app/scene.js';
+import {
+	mergeMovementInput,
+	type JoystickVector,
+} from '#root/ts/pulumi/baby.computer/app/controls.js';
 import style from '#root/ts/pulumi/baby.computer/app/style.module.css';
 
 const world = createPenguinWorld();
@@ -33,6 +37,7 @@ const MOTION_YAW_SENSITIVITY = Math.PI / 180;
 const MOTION_PITCH_SENSITIVITY = Math.PI / 270;
 const MEETING_DISTANCE = 2.4;
 const FIREWORK_COUNT = 6;
+const JOYSTICK_RADIUS = 44;
 
 type MotionBaseline = {
 	readonly beta: number;
@@ -98,6 +103,8 @@ export function PenguinSim() {
 	const lastDragPositionRef = useRef<{ x: number; y: number } | null>(null);
 	const lastAnimationTimeRef = useRef<number | null>(null);
 	const motionBaselineRef = useRef<MotionBaseline | null>(null);
+	const joystickPointerIdRef = useRef<number | null>(null);
+	const joystickInputRef = useRef<JoystickVector>({ x: 0, y: 0 });
 	const metPenguinsRef = useRef<Set<string>>(new Set());
 	const previousMetCountRef = useRef(0);
 
@@ -119,6 +126,7 @@ export function PenguinSim() {
 	const [motionPermissionNeeded, setMotionPermissionNeeded] = useState(false);
 	const [metCount, setMetCount] = useState(0);
 	const [fireworkTick, setFireworkTick] = useState(0);
+	const [joystickVector, setJoystickVector] = useState<JoystickVector>({ x: 0, y: 0 });
 
 	useEffect(() => {
 		const supportsMotion = typeof DeviceOrientationEvent !== 'undefined';
@@ -225,10 +233,10 @@ export function PenguinSim() {
 			const previous = lastAnimationTimeRef.current ?? timestamp;
 			lastAnimationTimeRef.current = timestamp;
 			const deltaSeconds = Math.min((timestamp - previous) / 1000, 0.05);
-			const input = {
+			const input = mergeMovementInput({
 				...movementFromKeys(keysRef.current),
 				jump: jumpRequestedRef.current,
-			};
+			}, joystickInputRef.current);
 			jumpRequestedRef.current = false;
 
 			if (
@@ -377,6 +385,51 @@ export function PenguinSim() {
 			draggingPointerIdRef.current = null;
 			lastDragPositionRef.current = null;
 		}
+	}
+
+	function updateJoystickFromPointer(clientX: number, clientY: number, target: Element) {
+		const bounds = target.getBoundingClientRect();
+		const centreX = bounds.left + (bounds.width / 2);
+		const centreY = bounds.top + (bounds.height / 2);
+		const deltaX = clientX - centreX;
+		const deltaY = clientY - centreY;
+		const distance = Math.hypot(deltaX, deltaY);
+		const scale = distance > JOYSTICK_RADIUS ? JOYSTICK_RADIUS / distance : 1;
+		const normalized = {
+			x: (deltaX * scale) / JOYSTICK_RADIUS,
+			y: (deltaY * scale) / JOYSTICK_RADIUS,
+		};
+		joystickInputRef.current = normalized;
+		setJoystickVector(normalized);
+	}
+
+	function releaseJoystick() {
+		joystickPointerIdRef.current = null;
+		joystickInputRef.current = { x: 0, y: 0 };
+		setJoystickVector({ x: 0, y: 0 });
+	}
+
+	function handleJoystickPointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+		joystickPointerIdRef.current = event.pointerId;
+		event.currentTarget.setPointerCapture(event.pointerId);
+		updateJoystickFromPointer(event.clientX, event.clientY, event.currentTarget);
+	}
+
+	function handleJoystickPointerMove(event: ReactPointerEvent<HTMLDivElement>) {
+		if (joystickPointerIdRef.current !== event.pointerId) {
+			return;
+		}
+
+		updateJoystickFromPointer(event.clientX, event.clientY, event.currentTarget);
+	}
+
+	function handleJoystickPointerUp(event: ReactPointerEvent<HTMLDivElement>) {
+		if (joystickPointerIdRef.current !== event.pointerId) {
+			return;
+		}
+
+		event.currentTarget.releasePointerCapture(event.pointerId);
+		releaseJoystick();
 	}
 
 	const visibleEncounter = nearestVisiblePenguin(
@@ -536,6 +589,24 @@ export function PenguinSim() {
 						{pose.position[0]![0]!.toFixed(1)}, {pose.position[1]![0]!.toFixed(1)}, {pose.position[2]![0]!.toFixed(1)}
 						{' · '}
 						{formatAngle(pose.yaw)} / {formatAngle(pose.pitch)}
+					</div>
+					<div className={style.overlayBottom}>
+						<div
+							className={style.joystickBase}
+							onPointerCancel={handleJoystickPointerUp}
+							onPointerDown={handleJoystickPointerDown}
+							onPointerMove={handleJoystickPointerMove}
+							onPointerUp={handleJoystickPointerUp}
+						>
+							<div
+								className={style.joystickThumb}
+								style={
+									{
+										transform: `translate(${joystickVector.x * JOYSTICK_RADIUS}px, ${joystickVector.y * JOYSTICK_RADIUS}px)`,
+									} as CSSProperties
+								}
+							/>
+						</div>
 					</div>
 				</div>
 			</section>

--- a/ts/pulumi/baby.computer/app/controls.ts
+++ b/ts/pulumi/baby.computer/app/controls.ts
@@ -1,0 +1,23 @@
+import type { MovementInput } from '#root/project/zemn.me/app/experiments/arena/scene.js';
+
+export interface JoystickVector {
+	readonly x: number;
+	readonly y: number;
+}
+
+function clampAxis(value: number): number {
+	return Math.max(-1, Math.min(1, value));
+}
+
+export function mergeMovementInput(
+	keyboard: MovementInput,
+	joystick: JoystickVector
+): MovementInput {
+	return {
+		forward: clampAxis(keyboard.forward - joystick.y),
+		strafe: clampAxis(keyboard.strafe + joystick.x),
+		sprint: keyboard.sprint,
+		jump: keyboard.jump,
+	};
+}
+

--- a/ts/pulumi/baby.computer/app/controls_test.ts
+++ b/ts/pulumi/baby.computer/app/controls_test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { mergeMovementInput } from '#root/ts/pulumi/baby.computer/app/controls.js';
+
+describe('mergeMovementInput', () => {
+	test('adds joystick axes to keyboard movement', () => {
+		const merged = mergeMovementInput(
+			{ forward: 1, jump: false, sprint: false, strafe: 0 },
+			{ x: -0.4, y: -0.6 }
+		);
+
+		expect(merged.forward).toBeCloseTo(1);
+		expect(merged.strafe).toBeCloseTo(-0.4);
+	});
+
+	test('clamps movement to valid range', () => {
+		const merged = mergeMovementInput(
+			{ forward: -1, jump: false, sprint: false, strafe: 1 },
+			{ x: 0.9, y: 0.8 }
+		);
+
+		expect(merged.forward).toBe(-1);
+		expect(merged.strafe).toBe(1);
+	});
+});

--- a/ts/pulumi/baby.computer/app/style.module.css
+++ b/ts/pulumi/baby.computer/app/style.module.css
@@ -101,9 +101,11 @@
 	left: 1rem;
 	right: 1rem;
 	top: 1rem;
+	bottom: 1rem;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
+	justify-content: space-between;
 	gap: 0.65rem;
 	pointer-events: none;
 }
@@ -129,6 +131,40 @@
 	font-size: 0.82rem;
 	line-height: 1.4;
 	color: #d8effb;
+}
+
+.overlayBottom {
+	width: 100%;
+	display: flex;
+	justify-content: flex-start;
+	align-items: flex-end;
+}
+
+.joystickBase {
+	width: 5.5rem;
+	height: 5.5rem;
+	border-radius: 999px;
+	border: 1px solid rgb(238 247 255 / 24%);
+	background: rgb(7 16 25 / 52%);
+	backdrop-filter: blur(8px);
+	box-shadow:
+		0 0.8rem 1.5rem rgb(0 0 0 / 25%),
+		inset 0 0 0 1px rgb(125 216 255 / 8%);
+	display: grid;
+	place-items: center;
+	touch-action: none;
+}
+
+.joystickThumb {
+	width: 2.3rem;
+	height: 2.3rem;
+	border-radius: 999px;
+	border: 1px solid rgb(238 247 255 / 28%);
+	background: linear-gradient(180deg, rgb(248 253 255 / 90%), rgb(143 214 242 / 68%));
+	box-shadow:
+		0 0.5rem 1rem rgb(0 0 0 / 28%),
+		inset 0 0 0 1px rgb(255 255 255 / 22%);
+	pointer-events: none;
 }
 
 .metCount {
@@ -207,6 +243,7 @@
 		left: 0.75rem;
 		right: 0.75rem;
 		top: 0.75rem;
+		bottom: 0.75rem;
 	}
 
 	.overlayTop {
@@ -220,5 +257,10 @@
 
 	.overlayStatus {
 		font-size: 0.75rem;
+	}
+
+	.joystickBase {
+		width: 5rem;
+		height: 5rem;
 	}
 }


### PR DESCRIPTION
### Motivation

- Provide an on-screen joystick so touch and pointer users can steer the penguin meeting simulation without relying on keyboard keys.
- Preserve existing keyboard controls by merging keyboard and joystick inputs so both input styles work together.

### Description

- Add a new `controls.ts` with `mergeMovementInput` and axis clamping to combine keyboard movement and joystick vectors safely.
- Add a HUD joystick to the bottom-left of the overlay in `client.tsx` with pointer handlers (`onPointerDown`, `onPointerMove`, `onPointerUp`, `onPointerCancel`) and runtime state to update the thumb position and movement vector; integrate the joystick vector into the per-frame movement via `mergeMovementInput`.
- Add UI styles in `style.module.css` for `.overlayBottom`, `.joystickBase`, and `.joystickThumb` and adjust overlay layout to place the joystick bottom-left.
- Add `controls_test.ts` to validate axis merging and clamping, and update `BUILD.bazel` to include the new sources and tests so Bazel builds and runs them.

### Testing

- Ran `gazelle` successfully to update workspace metadata and ensure build files are consistent.
- Ran `bazel test //ts/pulumi/baby.computer/app:tests` and the test target passed (cached); `controls_test` and `scene_test` executed as part of the suite and passed.
- No automated visual tests were run for the HUD layout, only unit tests and the Bazel test target were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee37750898832cb2e481f72edbba50)