### PR TITLE
Add crosshair targeting and treat interactions (pointer-lock + mobile)

### DIFF
--- a/ts/pulumi/baby.computer/app/client.tsx
+++ b/ts/pulumi/baby.computer/app/client.tsx
@@ -21,6 +21,7 @@ import { x, y, z } from '#root/ts/math/cartesian.js';
 import {
 	createPenguinWorld,
 	nearestVisiblePenguin,
+	targetedVisiblePenguin,
 } from '#root/ts/pulumi/baby.computer/app/scene.js';
 import style from '#root/ts/pulumi/baby.computer/app/style.module.css';
 
@@ -33,6 +34,8 @@ const MOTION_YAW_SENSITIVITY = Math.PI / 180;
 const MOTION_PITCH_SENSITIVITY = Math.PI / 270;
 const MEETING_DISTANCE = 2.4;
 const FIREWORK_COUNT = 6;
+const INTERACT_DISTANCE = 3.2;
+const INTERACT_SCREEN_DISTANCE = 120;
 
 type MotionBaseline = {
 	readonly beta: number;
@@ -119,6 +122,7 @@ export function PenguinSim() {
 	const [motionPermissionNeeded, setMotionPermissionNeeded] = useState(false);
 	const [metCount, setMetCount] = useState(0);
 	const [fireworkTick, setFireworkTick] = useState(0);
+	const [lastTreatMessage, setLastTreatMessage] = useState<string | null>(null);
 
 	useEffect(() => {
 		const supportsMotion = typeof DeviceOrientationEvent !== 'undefined';
@@ -298,6 +302,23 @@ export function PenguinSim() {
 		previousMetCountRef.current = metCount;
 	}, [metCount]);
 
+
+	function tryGiveTreat() {
+		const targeted = targetedVisiblePenguin(
+			world.penguins,
+			poseRef.current,
+			viewportSize.width,
+			viewportSize.height,
+			INTERACT_SCREEN_DISTANCE
+		);
+		if (targeted == null || targeted.penguin.distance > INTERACT_DISTANCE) {
+			setLastTreatMessage('No penguin close enough to receive a treat.');
+			return;
+		}
+
+		setLastTreatMessage(`You gave ${targeted.penguin.name} a fish treat. 🐟`);
+	}
+
 	function lockPointer() {
 		void viewportRef.current?.requestPointerLock();
 		viewportRef.current?.focus();
@@ -327,6 +348,10 @@ export function PenguinSim() {
 		viewportRef.current?.focus();
 
 		if (event.pointerType === 'mouse') {
+			if (locked) {
+				tryGiveTreat();
+				return;
+			}
 			lockPointer();
 			return;
 		}
@@ -530,6 +555,8 @@ export function PenguinSim() {
 							</span>
 						</div>
 					</div>
+					<button className={style.treatButton} onClick={tryGiveTreat} type="button">Give treat</button>
+					{lastTreatMessage != null ? <div className={style.treatStatus}>{lastTreatMessage}</div> : null}
 					<div className={style.overlayStatus}>
 						{locked ? 'pointer locked' : motionEnabled ? 'motion look' : 'tap or click viewport'}
 						{' · '}

--- a/ts/pulumi/baby.computer/app/scene.ts
+++ b/ts/pulumi/baby.computer/app/scene.ts
@@ -612,3 +612,45 @@ export function nearestVisiblePenguin(
 
 	return nearest;
 }
+
+export interface TargetedPenguinEncounter extends VisiblePenguinEncounter {
+	readonly screenDistance: number;
+}
+
+export function targetedVisiblePenguin(
+	penguins: readonly Penguin[],
+	pose: PlayerPose,
+	width: number,
+	height: number,
+	maxScreenDistancePx: number
+): TargetedPenguinEncounter | null {
+	const centerX = width / 2;
+	const centerY = height / 2;
+	let target: TargetedPenguinEncounter | null = null;
+
+	for (const penguin of penguins) {
+		const anchor = projectWorldPoint(penguinCaptionAnchor(penguin), pose, width, height);
+		if (!projectedWithinViewport(anchor, width, height)) {
+			continue;
+		}
+
+		const distance = Math.hypot(
+			x(penguin.position) - x(pose.position),
+			z(penguin.position) - z(pose.position)
+		);
+		const screenDistance = Math.hypot(x(anchor) - centerX, y(anchor) - centerY);
+		if (screenDistance > maxScreenDistancePx) {
+			continue;
+		}
+
+		if (target == null || screenDistance < target.screenDistance || (screenDistance === target.screenDistance && distance < target.penguin.distance)) {
+			target = {
+				penguin: { ...penguin, distance },
+				anchor,
+				screenDistance,
+			};
+		}
+	}
+
+	return target;
+}

--- a/ts/pulumi/baby.computer/app/scene_test.ts
+++ b/ts/pulumi/baby.computer/app/scene_test.ts
@@ -5,6 +5,7 @@ import {
 	createPenguinWorld,
 	nearestPenguin,
 	nearestVisiblePenguin,
+	targetedVisiblePenguin,
 } from '#root/ts/pulumi/baby.computer/app/scene.js';
 
 describe('baby.computer scene', () => {
@@ -63,4 +64,31 @@ describe('baby.computer scene', () => {
 		expect(visible).not.toBeNull();
 		expect(visible!.penguin.name).toBe('In Front');
 	});
+	test('targets the penguin nearest the crosshair within range', () => {
+		const world = createPenguinWorld();
+		const target = targetedVisiblePenguin(
+			world.penguins,
+			world.startPose,
+			1200,
+			800,
+			180
+		);
+
+		expect(target).not.toBeNull();
+		expect(target!.screenDistance).toBeLessThanOrEqual(180);
+	});
+
+	test('does not target penguins outside the allowed crosshair radius', () => {
+		const world = createPenguinWorld();
+		const target = targetedVisiblePenguin(
+			world.penguins,
+			world.startPose,
+			1200,
+			800,
+			5
+		);
+
+		expect(target).toBeNull();
+	});
+
 });

--- a/ts/pulumi/baby.computer/app/style.module.css
+++ b/ts/pulumi/baby.computer/app/style.module.css
@@ -222,3 +222,25 @@
 		font-size: 0.75rem;
 	}
 }
+
+.treatButton {
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	padding: 0.75rem 1rem;
+	border-radius: 0.75rem;
+	border: 1px solid rgb(238 247 255 / 25%);
+	background: rgb(7 22 35 / 78%);
+	color: #eef7ff;
+	font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+.treatStatus {
+	padding: 0.4rem 0.65rem;
+	border: 1px solid rgb(238 247 255 / 14%);
+	border-radius: 0.5rem;
+	background: rgb(5 12 20 / 62%);
+	font-size: 0.75rem;
+}


### PR DESCRIPTION
### Motivation
- Allow the player to interact with the penguin directly in front of them while in pointer-lock mode via a left-click, and provide a mobile-accessible tap control to give a treat to a nearby penguin.
- Provide a robust selection helper that prefers the visible penguin nearest the crosshair within a configurable screen radius.

### Description
- Added `targetedVisiblePenguin` in `ts/pulumi/baby.computer/app/scene.ts` which returns the visible penguin nearest the viewport center within a pixel radius and includes `screenDistance` for tie-breaking. 
- Implemented `tryGiveTreat` and pointer-down handling in `ts/pulumi/baby.computer/app/client.tsx` so that a left-click while pointer-lock is active attempts to give a treat to the targeted penguin (checks both screen radius and world distance), and added a HUD `Give treat` button for touch/mobile users. 
- Added small UI feedback (`lastTreatMessage`) and CSS classes in `ts/pulumi/baby.computer/app/style.module.css` for the treat button and status chip. 
- Added unit tests in `ts/pulumi/baby.computer/app/scene_test.ts` to verify targeting behaviour near the crosshair and that targets outside a tiny allowed radius are ignored.

### Testing
- Ran the package tests with Bazel: `bazel test //ts/pulumi/baby.computer/app:tests`, and the test target passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3fd1a2920832c9ecd0786c711ac30)