### PR TITLE
Move Glade content before hero video in DOM

### DIFF
--- a/project/me/zemn/components/Glade/BUILD.bazel
+++ b/project/me/zemn/components/Glade/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//bzl:rules.bzl", "bazel_lint")
-load("//ts:rules.bzl", "ts_project")
+load("//ts:rules.bzl", "jest_test", "ts_project")
 
 ts_project(
     name = "Glade",
@@ -44,7 +44,31 @@ filegroup(
     name = "all_ts_srcs",
     srcs = [
         "glade.tsx",
+        "glade_test.tsx",
         "menu.tsx",
     ],
     visibility = ["//:__subpackages__"],
+)
+
+ts_project(
+    name = "Glade_tests",
+    srcs = ["glade_test.tsx"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":Glade",
+        "//:node_modules/@jest/globals",
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/react",
+        "//:node_modules/@types/react-dom",
+        "//:node_modules/react",
+        "//:node_modules/react-dom",
+    ],
+)
+
+jest_test(
+    name = "tests",
+    srcs = ["glade_test.js"],
+    jsdom = True,
+    visibility = ["//:__subpackages__"],
+    deps = [":Glade_tests"],
 )

--- a/project/me/zemn/components/Glade/glade.tsx
+++ b/project/me/zemn/components/Glade/glade.tsx
@@ -51,14 +51,14 @@ export default function Glade(props: GladeProps) {
 	const isHomepage = pathname == '/';
 	return (
 		<main className={style.main} data-glade-layout>
+			<section className={style.content} data-glade-content>
+				{props.children}
+			</section>
 			<HeroVideo className={style.headerBgv} data-glade-banner />
 			<header className={style.banner} data-glade-banner>
 				<LetterHead />
 				<GladeMenu />
 			</header>
-			<section className={style.content} data-glade-content>
-				{props.children}
-			</section>
 			<section className={style.footer} data-glade-footer>
 				<h2 className={dividerHeadingClass}>
 					<span>⁂</span>

--- a/project/me/zemn/components/Glade/glade_test.tsx
+++ b/project/me/zemn/components/Glade/glade_test.tsx
@@ -1,0 +1,166 @@
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	expect,
+	it,
+	jest,
+} from '@jest/globals';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+import type { GladeProps } from './glade.js';
+
+jest.unstable_mockModule('next/navigation', () => ({
+	usePathname: () => '/article/example',
+}));
+
+jest.unstable_mockModule(
+	'#root/project/me/zemn/components/Glade/style.module.css',
+	() => ({
+		default: {
+			banner: 'banner',
+			content: 'content',
+			copyright: 'copyright',
+			footer: 'footer',
+			fullName: 'fullName',
+			future: 'future',
+			handle: 'handle',
+			headerBgv: 'headerBgv',
+			letterHead: 'letterHead',
+			logo: 'logo',
+			main: 'main',
+		},
+	})
+);
+
+jest.unstable_mockModule(
+	'#root/project/me/zemn/components/DividerHeading/index.js',
+	() => ({
+		dividerHeadingClass: 'dividerHeading',
+	})
+);
+
+jest.unstable_mockModule(
+	'#root/project/me/zemn/components/Glade/menu.js',
+	() => ({
+		GladeMenu: () => <nav aria-label="Site" />,
+	})
+);
+
+jest.unstable_mockModule(
+	'#root/project/me/zemn/components/HeroVideo/hero_video.js',
+	() => ({
+		HeroVideo: (props: {
+			readonly className?: string;
+			readonly 'data-glade-banner'?: boolean;
+		}) => (
+			<figure
+				className={props.className}
+				data-glade-banner={props['data-glade-banner']}
+			/>
+		),
+	})
+);
+
+jest.unstable_mockModule(
+	'#root/project/me/zemn/components/InlineLogin/inline_login.js',
+	() => ({
+		InlineLogin: () => null,
+	})
+);
+
+interface MockLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+	readonly children?: ReactNode;
+	readonly styleless?: boolean;
+}
+
+jest.unstable_mockModule(
+	'#root/project/me/zemn/components/Link/index.js',
+	() => ({
+		default: ({ children, styleless: _styleless, ...props }: MockLinkProps) => (
+			<a {...props}>{children}</a>
+		),
+	})
+);
+
+jest.unstable_mockModule(
+	'#root/project/me/zemn/components/TimeEye/index.js',
+	() => ({
+		TimeEye: ({ className }: { readonly className?: string }) => (
+			<svg className={className} />
+		),
+	})
+);
+
+jest.unstable_mockModule(
+	'#root/project/me/zemn/components/ZemnmezLogo/ZemnmezLogo.js',
+	() => ({
+		default: ({ className }: { readonly className?: string }) => (
+			<svg className={className} />
+		),
+	})
+);
+
+jest.unstable_mockModule('#root/project/me/zemn/bio/index.js', () => ({
+	Bio: {
+		who: {
+			fullName: {
+				language: 'en',
+				text: 'Thomas NJ Shadwell',
+			},
+			handle: {
+				language: 'en',
+				text: 'Zemnmez',
+			},
+		},
+	},
+}));
+
+jest.unstable_mockModule('#root/ts/constants/constants.js', () => ({
+	repoFirstCommitYear: 2008,
+}));
+
+jest.unstable_mockModule('#root/ts/react/lang/index.js', () => ({
+	text: (value: string | { readonly text: string }) =>
+		typeof value === 'string' ? value : value.text,
+}));
+
+let Glade: (props: GladeProps) => JSX.Element;
+let container: HTMLDivElement;
+let root: Root;
+
+beforeAll(async () => {
+	Glade = (await import('./glade.js')).default;
+});
+
+beforeEach(() => {
+	container = document.createElement('div');
+	root = createRoot(container);
+	document.body.appendChild(container);
+});
+
+afterEach(() => {
+	root.unmount();
+	container.remove();
+});
+
+it('renders article content before the hero video in the DOM', () => {
+	act(() => {
+		root.render(
+			<Glade>
+				<article>Article body</article>
+			</Glade>
+		);
+	});
+
+	const main = container.querySelector('[data-glade-layout]');
+	const content = container.querySelector('[data-glade-content]');
+	const heroVideo = container.querySelector('figure[data-glade-banner]');
+
+	expect(main?.firstElementChild).toBe(content);
+	expect(Array.from(main!.children).indexOf(content!)).toBeLessThan(
+		Array.from(main!.children).indexOf(heroVideo!)
+	);
+});


### PR DESCRIPTION

  Render article content before the decorative hero video so generated
  descriptions pick up article text first, while preserving the existing grid
  layout. Add a regression test for Glade source order
