### PR TITLE
[codex] Tune dark mode teal palette

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ you may not need to update this file at all.
 
 This file is reserved for short, pithy learnings that will save time in future.
 
+Code comments should explain durable intent; avoid anchoring them to transient
+previous states that will stop making sense after future edits.
+
 Final note before we get into the good stuff -- use a LOCAL AGENTS.md wherever
 possible. i.e. if the note is relevant to code in ts/pulumi, put the note in
 ts/pulumi/AGENTS.md instead.

--- a/project/me/zemn/app/base.css
+++ b/project/me/zemn/app/base.css
@@ -28,12 +28,8 @@ body,
 }
 
 /*
-	Dark mode colours have been generated
-	by sampling light mode colours and
-	adjusting their lightness in the CIELAB
-	colour space.
-
-	See: https://colorizer.org/
+	Dark mode colours keep a low-lightness palette while shifting hue
+	toward the light foreground teal in CIELAB.
 */
 @media screen and (prefers-color-scheme: dark) {
 	:root {
@@ -42,13 +38,13 @@ body,
 		https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
 		*/
 		color-scheme: dark;
-		--background-color: #010;
-		--foreground-color: #96a497;
-		--visited-link-color: #ad554b;
-		--error-color: #ad554b;
-		--link-color: #5b880a;
-		--highlight-color: #c7b26a;
-		--highlight-foreground-color: #010;
+		--background-color: #00130e;
+		--foreground-color: #8ca6a2;
+		--visited-link-color: #92635e;
+		--error-color: #92635e;
+		--link-color: #5e8645;
+		--highlight-color: #b7b58c;
+		--highlight-foreground-color: #00130e;
 	}
 }
 

--- a/project/me/zemn/app/layout.tsx
+++ b/project/me/zemn/app/layout.tsx
@@ -92,7 +92,7 @@ export default RootLayout;
 
 export const metadata: Metadata = {
 	themeColor: [
-		{ media: '(prefers-color-scheme: dark)', color: '#010' },
+		{ media: '(prefers-color-scheme: dark)', color: '#00130e' },
 		{ media: '(prefers-color-scheme: light)', color: '#fff' },
 	],
 	authors: [{ name: text(Bio.who.fullName), url: 'https://zemn.me' }],


### PR DESCRIPTION
## Summary

- Shift the existing dark mode palette toward the light-mode teal foreground in CIELAB space while preserving each color's lightness.
- Update the dark browser theme color to match the revised background.

## Impact

Dark mode keeps the older palette's weight and contrast roles, but now feels more connected to the amended light-mode teal foreground.

## Validation

- `./sh/bin/biome check --write --formatter-enabled=false --linter-enabled=true --assist-enabled=true --enforce-assist=true --config-path=$(pwd)/biome.json --no-errors-on-unmatched $(pwd)/project/me/zemn/app/base.css $(pwd)/project/me/zemn/app/layout.tsx`
- `./sh/bin/bazel run //:gazelle`
- `./sh/bin/bazel test //project/me/zemn/app/...`