### PR TITLE
[codex] Fix Real World AI Security date

### DIFF
--- a/project/me/zemn/bio/bio.ts
+++ b/project/me/zemn/bio/bio.ts
@@ -201,7 +201,7 @@ export const Bio = {
 				'Frances C. Arrillaga Alumni Center, 326 Galvez St, Stanford, CA 94305',
 			title: en`Beyond Prompt Injection: Agentic AI Attacks in the Real World`,
 			publisher: en`Real World AI Security`,
-			date: date(23, 'jun', 2026), // TBD
+			date: date(24, 'jun', 2026),
 			url: linkToHighlight(
 				url`https://seclab.stanford.edu/RealWorldAIsec/`,
 				{


### PR DESCRIPTION
## Summary

- Correct the Real World AI Security Conference bio timeline entry from June 23, 2026 to June 24, 2026.
- Remove the stale `TBD` marker from the date.

## Impact

The bio timeline now reflects the actual Wednesday, June 24, 2026 session date.

## Validation

- `./sh/bin/bazel run //:gazelle`
- `./sh/bin/bazel test //project/me/zemn/bio/...`