### PR TITLE
Hide availability from signed-out menu

### DIFF
--- a/project/me/zemn/components/Glade/menu.tsx
+++ b/project/me/zemn/components/Glade/menu.tsx
@@ -13,6 +13,11 @@ export function GladeMenu() {
 	const detailsRef = useRef<HTMLDetailsElement | null>(null);
 	const [fut_idToken] = useZemnMeAuth();
 	const fut_scopes = useGetMeScopes(fut_idToken);
+	const isLoggedIn = fut_idToken(
+		() => true,
+		() => false,
+		() => false
+	);
 
 	useEffect(() => {
 		const onPointerDown = (event: PointerEvent) => {
@@ -41,8 +46,10 @@ export function GladeMenu() {
 	const visibleSections = navSections
 		.map(section => ({
 			...section,
-			links: section.links.filter(link =>
-				isLinkVisible(link.requiredScope)
+			links: section.links.filter(
+				link =>
+					(!link.requiresAuthentication || isLoggedIn) &&
+					isLinkVisible(link.requiredScope)
 			),
 		}))
 		.filter(section => section.links.length > 0);

--- a/project/me/zemn/components/Glade/menu_test.tsx
+++ b/project/me/zemn/components/Glade/menu_test.tsx
@@ -1,4 +1,11 @@
-import { afterEach, beforeAll, beforeEach, expect, it, jest } from '@jest/globals';
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	expect,
+	it,
+	jest,
+} from '@jest/globals';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
@@ -37,28 +44,31 @@ interface MockLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 jest.unstable_mockModule(
 	'#root/project/me/zemn/components/Link/index.js',
 	() => ({
-		default: ({ children, styleless: _styleless, ...props }: MockLinkProps) => (
-			<a {...props}>{children}</a>
-		),
+		default: ({
+			children,
+			styleless: _styleless,
+			...props
+		}: MockLinkProps) => <a {...props}>{children}</a>,
 	})
 );
 
-jest.unstable_mockModule(
-	'#root/project/me/zemn/hook/useZemnMeApi.js',
-	() => ({
-		useGetMeScopes:
-			() =>
-			(onResolved: (scopes: readonly string[]) => unknown) =>
-				onResolved([]),
-	})
-);
+jest.unstable_mockModule('#root/project/me/zemn/hook/useZemnMeApi.js', () => ({
+	useGetMeScopes:
+		() => (onResolved: (scopes: readonly string[]) => unknown) =>
+			onResolved([]),
+}));
 
-jest.unstable_mockModule(
-	'#root/project/me/zemn/hook/useZemnMeAuth.js',
-	() => ({
-		useZemnMeAuth: () => [undefined],
-	})
-);
+let isLoggedIn = false;
+
+jest.unstable_mockModule('#root/project/me/zemn/hook/useZemnMeAuth.js', () => ({
+	useZemnMeAuth: () => [
+		(
+			onResolved: (token: string) => unknown,
+			_onRejected: () => unknown,
+			onPending: () => unknown
+		) => (isLoggedIn ? onResolved('token') : onPending()),
+	],
+}));
 
 let GladeMenu: () => JSX.Element;
 let container: HTMLDivElement;
@@ -69,6 +79,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+	isLoggedIn = false;
 	container = document.createElement('div');
 	root = createRoot(container);
 	document.body.appendChild(container);
@@ -110,4 +121,30 @@ it('retracts the menu when tapping outside it', () => {
 
 	expect(details.open).toBe(false);
 	outside.remove();
+});
+
+it('hides availability when signed out', () => {
+	act(() => {
+		root.render(<GladeMenu />);
+	});
+
+	expect(
+		Array.from(container.querySelectorAll('a')).some(
+			link => link.textContent === 'Availability'
+		)
+	).toBe(false);
+});
+
+it('shows availability when signed in', () => {
+	isLoggedIn = true;
+
+	act(() => {
+		root.render(<GladeMenu />);
+	});
+
+	expect(
+		Array.from(container.querySelectorAll('a')).some(
+			link => link.textContent === 'Availability'
+		)
+	).toBe(true);
 });

--- a/project/me/zemn/navigation/navigation.ts
+++ b/project/me/zemn/navigation/navigation.ts
@@ -2,20 +2,20 @@ import type { components } from '#root/project/me/zemn/api/api_client.gen.js';
 
 type ApiScopes = components['schemas']['OAuthScopes'];
 
-export type RequiredScope =
-	keyof Pick<
-		ApiScopes,
-		| 'admin_analytics_read'
-		| 'admin_users_manage'
-		| 'callbox_key'
-		| 'grievance_portal'
-		| 'minecraft'
-	>;
+export type RequiredScope = keyof Pick<
+	ApiScopes,
+	| 'admin_analytics_read'
+	| 'admin_users_manage'
+	| 'callbox_key'
+	| 'grievance_portal'
+	| 'minecraft'
+>;
 
 export interface NavigationLink {
 	readonly description?: string;
 	readonly href: string;
 	readonly label: string;
+	readonly requiresAuthentication?: boolean;
 	readonly requiredScope?: RequiredScope;
 }
 
@@ -31,7 +31,11 @@ export interface NavigationSection {
 export const pageLinks: readonly NavigationLink[] = [
 	{ href: '/', label: 'Home' },
 	{ href: '/cv', label: 'CV' },
-	{ href: '/availability', label: 'Availability' },
+	{
+		href: '/availability',
+		label: 'Availability',
+		requiresAuthentication: true,
+	},
 ];
 
 export const toolLinks: readonly NavigationLink[] = [
@@ -71,9 +75,8 @@ export const articleLinks: readonly ArticleNavigationLink[] = [
 	},
 ];
 
-export const releasedArticleLinks: readonly NavigationLink[] = articleLinks.filter(
-	link => link.released
-);
+export const releasedArticleLinks: readonly NavigationLink[] =
+	articleLinks.filter(link => link.released);
 
 export const experimentLinks: readonly NavigationLink[] = [
 	{

--- a/project/me/zemn/navigation/navigation_test.ts
+++ b/project/me/zemn/navigation/navigation_test.ts
@@ -5,6 +5,7 @@ import {
 	articleLinks,
 	experimentLinks,
 	navSections,
+	pageLinks,
 	releasedArticleLinks,
 	toolLinks,
 } from '#root/project/me/zemn/navigation/navigation.js';
@@ -52,7 +53,6 @@ it('includes public content and redirect pages', () => {
 		'/article/2019/cors',
 		'/article/2024/clean',
 		'/article/2024/missing',
-		'/availability',
 		'/cv',
 		'/tool/elastictabs',
 	];
@@ -65,6 +65,14 @@ it('includes public content and redirect pages', () => {
 	expect(hrefs).not.toContain('/linkedin');
 	expect(hrefs).not.toContain('/src');
 	expect(hrefs).not.toContain('/twitter');
+});
+
+it('requires authentication for availability in the menu', () => {
+	expect(pageLinks.find(link => link.href === '/availability')).toEqual(
+		expect.objectContaining({
+			requiresAuthentication: true,
+		})
+	);
 });
 
 it('hides unreleased articles from the menu', () => {
@@ -84,17 +92,17 @@ it('only includes released article links in the menu', () => {
 	const expected = articleLinks
 		.filter(link => link.released)
 		.map(link => link.href);
-	const actual = navSections.find(section => section.label === 'Articles')?.links.map(
-		link => link.href
-	);
+	const actual = navSections
+		.find(section => section.label === 'Articles')
+		?.links.map(link => link.href);
 
 	expect(actual).toEqual(expected);
 });
 
 it('puts tools in their own menu section', () => {
-	const actual = navSections.find(section => section.label === 'Tools')?.links.map(
-		link => link.href
-	);
+	const actual = navSections
+		.find(section => section.label === 'Tools')
+		?.links.map(link => link.href);
 
 	expect(actual).toEqual(toolLinks.map(link => link.href));
 	expect(actual).toEqual(['/tool/elastictabs']);


### PR DESCRIPTION
## What changed

- mark the Availability hamburger-menu link as requiring authentication
- filter authentication-only links using the existing zemn.me auth future
- add component coverage for both signed-out and signed-in menu states

## Why

The availability page should remain directly accessible, but it should not be advertised in the site hamburger menu to signed-out visitors.

## Validation

- `bazel test //project/me/zemn/components/Glade:tests //project/me/zemn/navigation:tests`
- Gazelle
- Biome formatting/linting